### PR TITLE
Added entrypoint script under speakeasy.cli

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,28 +2,28 @@
 
 import setuptools
 
-with open('README.md', 'r', encoding='utf8') as fh:
+with open("README.md", "r", encoding="utf8") as fh:
     long_description = fh.read()
 
-with open("speakeasy/version.py", encoding='utf8') as fp:
+with open("speakeasy/version.py", encoding="utf8") as fp:
     vl = fp.readline()
-    gv, ver_num = vl.split('=')
-    if gv.strip() != '__version__':
-        raise Exception('Invalid version file found')
-    version = ver_num.strip().strip("\"\'")
+    gv, ver_num = vl.split("=")
+    if gv.strip() != "__version__":
+        raise Exception("Invalid version file found")
+    version = ver_num.strip().strip("\"'")
 
 with open("requirements.txt", encoding="utf-8") as f:
     requirements = [line.strip() for line in f.readlines()]
 
 setuptools.setup(
-    name='speakeasy-emulator',
-    author='Andrew Davis',
-    description='Speakeasy malware emulation framework',
+    name="speakeasy-emulator",
+    author="Andrew Davis",
+    description="Speakeasy malware emulation framework",
     version=version,
     long_description=long_description,
-    long_description_content_type='text/markdown',
+    long_description_content_type="text/markdown",
     packages=setuptools.find_packages(),
-    url='https://github.com/fireeye/speakeasy',
+    url="https://github.com/fireeye/speakeasy",
     include_package_data=True,
     install_requires=requirements,
     classifiers=[
@@ -31,5 +31,6 @@ setuptools.setup(
         "License :: OSI Approved :: MIT License",
         "Operating System :: OS Independent",
     ],
-    python_requires='>=3.6',
+    python_requires=">=3.6",
+    entry_points={"console_scripts": ["speakeasy=speakeasy.cli:main"]},
 )

--- a/speakeasy/__main__.py
+++ b/speakeasy/__main__.py
@@ -1,0 +1,4 @@
+# Copyright (C) 2020 FireEye, Inc. All Rights Reserved.
+from speakeasy.cli import main
+
+main()

--- a/speakeasy/cli.py
+++ b/speakeasy/cli.py
@@ -197,7 +197,8 @@ class Main(object):
                     f.write(report)
 
 
-if __name__ == '__main__':
+def main():
+    """ speakeasy command line entrypoint """
 
     parser = argparse.ArgumentParser(description='Emulate a Windows binary with speakeasy')
     parser.add_argument('-t', '--target', action='store', dest='target',
@@ -245,3 +246,6 @@ if __name__ == '__main__':
                                              'speakeasy itself (using pdb.set_trace()).\n')
 
     Main(parser)
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This pull request moves `run_speakeasy.py` into `speakeasy/cli.py`, and creates an `entrypoint` field in `setup.py` which installs a script named `speakeasy` when installing the python module. The result is that a user can do:

```sh
$ pip install speakeasy-emulator
# Or
$ python setup.py install
# Now running speakeasy is simple from anywhere
$ speakeasy --help
```

I also added a `__main__.py` file to the module which simply executes the CLI entrypoint. This makes the following also valid/possible:

```sh
python -m speakeasy
```

This would fix #69.

I'm just realizing that `python-black` formatted the files which I edited. It appears the only changes made were using double quotes instead of single. If this is unacceptable for the purposes of this pull request, I'm happy to revert the changes, and then ensure that it's not formatted with Black in order to prevent that. Let me know. :+1: 