### PR TITLE
Support for StrStr in shlwapi

### DIFF
--- a/speakeasy/winenv/api/usermode/shlwapi.py
+++ b/speakeasy/winenv/api/usermode/shlwapi.py
@@ -54,7 +54,36 @@ class Shlwapi(api.ApiHandler):
             argv[0] = pn
 
         return rv
+    
+    @apihook('StrStr', argc=2)
+    def StrStr(self, emu, argv, ctx={}):
+        '''
+        PCSTR StrStr(
+            PCSTR pszFirst,
+            PCSTR pszSrch
+        );
+        '''
 
+        hay, needle = argv
+
+        cw = self.get_char_width(ctx)
+
+        if hay:
+            _hay = self.read_mem_string(hay, cw)
+            argv[0] = _hay
+
+        if needle:
+            needle = self.read_mem_string(needle, cw)
+            argv[1] = needle
+
+        ret = _hay.find(needle)
+        if ret != -1:
+            ret = hay + ret
+        else:
+            ret = 0
+
+        return ret
+    
     @apihook('StrStrI', argc=2)
     def StrStrI(self, emu, argv, ctx={}):
         '''


### PR DESCRIPTION
Small API addition.  

Adding in support for `StrStr`, Borrowing the logic from `StrStrI` within Shlwapi.  

Encountered `StrStrW` within sample, can be observed in `be514549a2e654706aeeaa15c8cffce504f0e271c904fe07d865f3999ebaa61f`