### PR TITLE
Fix shellcode bin_base_name uninitialized

### DIFF
--- a/speakeasy/windows/win32.py
+++ b/speakeasy/windows/win32.py
@@ -127,6 +127,7 @@ class Win32Emulator(WindowsEmulator):
         """
         Load a module into the emulator space from the specified path
         """
+        self._init_name(path, data)
         pe = self.load_pe(path=path, data=data, imp_id=w32common.IMPORT_HOOK_ADDR)
 
         if pe.arch == _arch.ARCH_X86:
@@ -147,23 +148,12 @@ class Win32Emulator(WindowsEmulator):
             if not self.disasm_eng:
                 self.disasm_eng = cs.Cs(cs.CS_ARCH_X86, disasm_mode)
 
-        if not data:
-            file_name = os.path.basename(path)
-            mod_name = os.path.splitext(file_name)[0]
-
-        else:
-            mod_hash = hashlib.sha256()
-            mod_hash.update(data)
-            mod_hash = mod_hash.hexdigest()
-            mod_name = mod_hash
-            file_name = '%s.exe' % (mod_name)
-
         self.api = WindowsApi(self)
 
         cd = self.get_cd()
         if not cd.endswith('\\'):
             cd += '\\'
-        emu_path = cd + file_name
+        emu_path = cd + self.file_name
 
         if not data:
             with open(path, 'rb') as f:
@@ -181,7 +171,7 @@ class Win32Emulator(WindowsEmulator):
         if self.cd:
             if not self.cd.endswith('\\'):
                 self.cd += '\\'
-            emu_path = self.cd + os.path.basename(file_name)
+            emu_path = self.cd + os.path.basename(self.file_name)
 
         pe.set_emu_path(emu_path)
 
@@ -242,7 +232,7 @@ class Win32Emulator(WindowsEmulator):
                     pass
 
         self.mem_map(pe.image_size, base=base,
-                tag='emu.module.%s' % (mod_name))
+                tag='emu.module.%s' % (self.mod_name))
 
         self.modules.append((pe, ranges, emu_path))
         self.mem_write(pe.base, pe.mapped_image)
@@ -419,6 +409,18 @@ class Win32Emulator(WindowsEmulator):
 
         return
 
+    def _init_name(self, path, data=None):
+        if not data:
+            self.file_name = os.path.basename(path)
+            self.mod_name = os.path.splitext(self.file_name)[0]
+        else:
+            mod_hash = hashlib.sha256()
+            mod_hash.update(data)
+            mod_hash = mod_hash.hexdigest()
+            self.mod_name = mod_hash
+            self.file_name = f"{self.mod_name}.exe"
+        self.bin_base_name = os.path.basename(self.file_name)
+
     def emulate_module(self, path):
         """
         Load and emulate binary from the given path
@@ -431,7 +433,7 @@ class Win32Emulator(WindowsEmulator):
         Load position independent code (i.e. shellcode) to prepare for emulation
         """
         sc_hash = None
-
+        self._init_name(path, data)
         if arch == 'x86':
             arch = _arch.ARCH_X86
         elif arch in ('x64', 'amd64'):
@@ -460,6 +462,7 @@ class Win32Emulator(WindowsEmulator):
             raise Win32EmuError('Unsupported architecture: %s' % self.arch)
 
         self.emu_eng.init_engine(_arch.ARCH_X86, self.arch)
+
 
         if not self.disasm_eng:
             self.disasm_eng = cs.Cs(cs.CS_ARCH_X86, disasm_mode)


### PR DESCRIPTION
Hi guys! I was executing some shellcodes through speakeasy and I encountered the following error
```
0x77001b12: shellcode: Caught error: 'Win32Emulator' object has no attribute 'bin_base_name'
* Finished emulating
```
The patch that I made is very small and cover only this small use case, but the IDE is warning me that can be more attribute that are uninitialized in the `win32.py` module.