### PR TITLE
fix missing requirements.txt in dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,6 +28,7 @@ WORKDIR ${APP_HOME}
 
 COPY ./speakeasy/ ${APP_HOME}/speakeasy
 COPY ./setup.py ${APP_HOME}
+COPY ./requirements.txt ${APP_HOME}
 COPY ./README.md ${APP_HOME}
 COPY ./MANIFEST.in ${APP_HOME}
 COPY ./examples/ ${APP_HOME}/examples


### PR DESCRIPTION
was failing on docker image curation due to a missing requirements.txt file, which is now being pulled in.

was previously failing to build 