### PR TITLE
Added AddVectoredExceptionHandler in Kernel32. This is already define…

### DIFF
--- a/speakeasy/winenv/api/usermode/kernel32.py
+++ b/speakeasy/winenv/api/usermode/kernel32.py
@@ -5551,3 +5551,17 @@ class Kernel32(api.ApiHandler):
         self.mem_write(lpSystemTimeAsFileTime, self.get_bytes(ft))
 
         return
+
+    @apihook('AddVectoredExceptionHandler', argc=2)
+    def AddVectoredExceptionHandler(self, emu, argv, ctx={}):
+        '''
+        PVOID AddVectoredExceptionHandler(
+            ULONG                       First,
+            PVECTORED_EXCEPTION_HANDLER Handler
+        );
+        '''
+        First, Handler = argv
+
+        emu.add_vectored_exception_handler(First, Handler)
+
+        return Handler


### PR DESCRIPTION
…d as RtlAddVectoredExceptionHandler in ntdll

from wine I see is defined as the same function
@ stdcall AddVectoredContinueHandler(long ptr) ntdll.RtlAddVectoredContinueHandler