### PR TITLE
Initial iphlpapi.dll support

### DIFF
--- a/speakeasy/binemu.py
+++ b/speakeasy/binemu.py
@@ -121,6 +121,7 @@ class BinaryEmulator(MemoryManager):
         self.keep_memory_on_free = config.get('keep_memory_on_free', False)
 
         self.network_config = config.get('network', {})
+        self.network_adapters = self.network_config.get('adapters', [])
         self.command_line = config.get('command_line', '')
 
     def get_emu_version(self):
@@ -206,6 +207,12 @@ class BinaryEmulator(MemoryManager):
         Get the network settings specified in the network section of the config file
         """
         return self.network_config
+
+    def get_network_adapters(self):
+        """
+        Get the network adapters specified in the network section of the config file
+        """
+        return self.network_adapters
 
     def get_filesystem_config(self):
         """

--- a/speakeasy/config_schema.json
+++ b/speakeasy/config_schema.json
@@ -429,6 +429,43 @@
                             }
                         }
                     }
+                },
+                "adapters": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "name": {
+                                "type": "string",
+                                "description": "Name of the adapter"
+                            },
+                            "description": {
+                                "type": "string",
+                                "description": "Description of the adapter"
+                            },
+                            "mac_address": {
+                                "type": "string",
+                                "description": "Hardware address of the adapter"
+                            },
+                            "type": {
+                                "type": "string",
+                                "description": "Adapter type (e.g., 'ethernet')"
+                            },
+                            "ip_address": {
+                                "type": "string",
+                                "description": "IPv4 address associated with the adapter. Currently only supports one address instead of a list."
+                            },
+                            "subnet_mask": {
+                                "type": "string",
+                                "description": "IPv4 subnet mask"
+                            },
+                            "dhcp_enabled": {
+                                "type": "boolean",
+                                "description": "DHCP enabled"
+                            }
+                        },
+                        "additionalProperties": false
+                    }
                 }
             },
             "additionalProperties": false

--- a/speakeasy/configs/default.json
+++ b/speakeasy/configs/default.json
@@ -166,7 +166,6 @@
     },
 
     "network": {
-
         "dns": {
             "names":{
                 "speakeasy_host": "127.0.0.1",
@@ -181,7 +180,6 @@
                 }
             ]
         },
-
         "http": {
             "responses": [
                 {
@@ -213,7 +211,18 @@
                     "path": "$ROOT$/resources/web/stager.bin"
                 }
             ]
-        }
+        },
+        "adapters": [
+            {
+                "name": "{00000000-0000-0000-0000-000000000000}",
+                "description": "Intel(R) PRO/1000 MT Network Connection",
+                "mac_address": "00-13-CE-12-34-56",
+                "type": "ethernet",
+                "ip_address": "127.0.0.1",
+                "subnet_mask": "255.0.0.0",
+                "dhcp_enabled": true
+            }
+        ]
     },
 
     "processes": [
@@ -547,6 +556,11 @@
                     "name": "wkscli",
                     "base_addr": "0x5fc00000",
                     "path": "C:\\Windows\\system32\\wkscli.dll"
+                },
+                {
+                    "name": "iphlpapi",
+                    "base_addr": "0x5fd00000",
+                    "path": "C:\\Windows\\system32\\iphlpapi.dll"
                 }
         ]
     }

--- a/speakeasy/winenv/api/usermode/iphlpapi.py
+++ b/speakeasy/winenv/api/usermode/iphlpapi.py
@@ -1,0 +1,52 @@
+# Copyright (C) 2022 Mandiant, Inc. All Rights Reserved.
+
+import binascii
+
+import speakeasy.winenv.defs.windows.iphlpapi as iphlpapi_types
+
+from .. import api
+
+
+class Iphlpapi(api.ApiHandler):
+    """
+    Implements exported functions from iphlpapi.dll
+    """
+    name = 'iphlpapi'
+    apihook = api.ApiHandler.apihook
+    impdata = api.ApiHandler.impdata
+
+    def __init__(self, emu):
+
+        super(Iphlpapi, self).__init__(emu)
+
+        self.iphlpapi_types = iphlpapi_types
+
+    @apihook('GetAdaptersInfo', argc=2)
+    def GetAdaptersInfo(self, emu, argv, ctx={}):
+        ptr_adapter_info, size_ptr = argv
+        rv = 0
+
+        adapters = emu.get_network_adapters()
+        adapter_count = len(adapters)
+        for index, adapter in enumerate(adapters):
+            adapter_info = self.iphlpapi_types.IP_ADAPTER_INFO(emu.get_ptr_size())
+
+            adapter_info.AdapterName = adapter.get('name').encode('utf-8')
+            adapter_info.Description = adapter.get('description').encode('utf-8')
+            adapter_info.AddressLength = 6
+            adapter_info.Address = binascii.unhexlify(adapter.get('mac_address').replace('-', ''))
+            adapter_info.Type = iphlpapi_types.get_adapter_type(adapter.get('type'))
+            adapter_info.IpAddressList.IpAddress = adapter.get('ip_address').encode('utf-8')
+            adapter_info.IpAddressList.IpMask = adapter.get('subnet_mask').encode('utf-8')
+            adapter_info.DhcpEnabled = adapter.get('dhcp_enabled')
+
+            if index < adapter_count - 1:
+                ptr_next = self.mem_alloc(adapter_info.sizeof(), tag='api.struct.IP_ADAPTER_INFO')
+            else:
+                ptr_next = 0
+
+            adapter_info.Next = ptr_next
+            self.mem_write(ptr_adapter_info, self.get_bytes(adapter_info))
+            ptr_adapter_info = ptr_next
+
+        return rv

--- a/speakeasy/winenv/defs/windows/iphlpapi.py
+++ b/speakeasy/winenv/defs/windows/iphlpapi.py
@@ -1,0 +1,54 @@
+# Copyright (C) 2022 Mandiant, Inc. All Rights Reserved.
+
+from speakeasy.struct import EmuStruct, Ptr
+import ctypes as ct
+
+MAX_ADAPTER_NAME_LENGTH = 256
+MAX_ADAPTER_DESCRIPTION_LENGTH = 128
+MAX_ADAPTER_ADDRESS_LENGTH = 8
+
+MIB_IF_TYPE_OTHER = 1
+MIB_IF_TYPE_ETHERNET = 6
+MIB_IF_TYPE_PPP = 23
+MIB_IF_TYPE_LOOPBACK = 24
+MIB_IF_TYPE_SLIP = 28
+
+IF_TYPE_ISO88025_TOKENRING = 9
+IF_TYPE_IEEE80211 = 71
+
+
+class IP_ADAPTER_INFO(EmuStruct):
+    def __init__(self, ptr_size):
+        super().__init__(ptr_size)
+        self.Next = Ptr
+        self.ComboIndex = ct.c_uint32
+        self.AdapterName = ct.c_uint8 * (MAX_ADAPTER_NAME_LENGTH + 4)
+        self.Description = ct.c_uint8 * (MAX_ADAPTER_DESCRIPTION_LENGTH + 4)
+        self.AddressLength = ct.c_uint32
+        self.Address = ct.c_uint8 * MAX_ADAPTER_ADDRESS_LENGTH
+        self.Index = ct.c_uint32
+        self.Type = ct.c_uint32
+        self.DhcpEnabled = ct.c_bool
+        self.CurrentIpAddress = Ptr
+        self.IpAddressList = IP_ADDR_STRING
+        self.GatewayList = IP_ADDR_STRING
+        self.DhcpServer = IP_ADDR_STRING
+        self.HaveWins = ct.c_uint32
+        self.PrimaryWinsServer = IP_ADDR_STRING
+        self.SecondaryWinsServer = IP_ADDR_STRING
+        self.LeaseObtained = ct.c_uint32
+        self.LeaseExpires = ct.c_uint32
+
+
+class IP_ADDR_STRING(EmuStruct):
+    def __init__(self, ptr_size):
+        super().__init__(ptr_size)
+        self.Next = Ptr
+        self.IpAddress = ct.c_uint8 * 16
+        self.IpMask = ct.c_uint8 * 16
+        self.Context = ct.c_uint32
+
+
+def get_adapter_type(type_str):
+    if type_str == 'ethernet':
+        return MIB_IF_TYPE_ETHERNET


### PR DESCRIPTION
Primary intent was to support network adapters based on the `GetAdaptersInfo` function. Includes the ability to specify a list of network adapters in the configuration. For each adapter in the config, a minimal list of properties can be defined (e.g., name, description, type, IP address, MAC address).