### PR TITLE
Additional SID support

### DIFF
--- a/speakeasy/binemu.py
+++ b/speakeasy/binemu.py
@@ -163,7 +163,7 @@ class BinaryEmulator(MemoryManager):
 
     def get_user(self):
         """
-        Get the current emulated user's name
+        Get the current emulated user properties
         """
         return self.user_config
 

--- a/speakeasy/config_schema.json
+++ b/speakeasy/config_schema.json
@@ -216,6 +216,10 @@
                 "is_admin": {
                     "type": "boolean",
                     "description": "Determines if this user is an administrator"
+                },
+                "sid": {
+                    "type": "string",
+                    "description": "SID associated with the user account"
                 }
             },
             "additionalProperties": false,

--- a/speakeasy/configs/default.json
+++ b/speakeasy/configs/default.json
@@ -45,7 +45,8 @@
 
     "user": {
         "name": "speakeasy_user",
-        "is_admin": true
+        "is_admin": true,
+        "sid": "S-1-5-21-1111111111-2222222222-3333333333-1001"
     },
 
     "api_hammering": {

--- a/speakeasy/winenv/api/usermode/kernel32.py
+++ b/speakeasy/winenv/api/usermode/kernel32.py
@@ -1240,6 +1240,25 @@ class Kernel32(api.ApiHandler):
         obj.suspend_count += 1
         return rv
 
+    @apihook('TerminateThread', argc=2)
+    def TerminateThread(self, emu, argv, ctx={}):
+        '''
+        BOOL TerminateThread(
+          [in, out] HANDLE hThread,
+          [in]      DWORD  dwExitCode
+        );
+        '''
+        hThread, dwExitCode = argv
+        rv = 0
+        obj = self.get_object_from_handle(hThread)
+        if not obj:
+            return rv
+
+        rv = 1
+        # Thread termination not implemented
+
+        return rv
+
     @apihook('GetThreadId', argc=1)
     def GetThreadId(self, emu, argv, ctx={}):
         """
@@ -4595,7 +4614,7 @@ class Kernel32(api.ApiHandler):
 
         return
 
-    @apihook('VerSetConditionMask', argc=3)
+    @apihook('VerSetConditionMask', argc=3, conv=e_arch.CALL_CONV_CDECL)
     def VerSetConditionMask(self, emu, argv, ctx={}):
         '''
         NTSYSAPI ULONGLONG VerSetConditionMask(
@@ -4609,7 +4628,7 @@ class Kernel32(api.ApiHandler):
 
         return 0
 
-    @apihook('VerifyVersionInfo', argc=3)
+    @apihook('VerifyVersionInfo', argc=3, conv=e_arch.CALL_CONV_CDECL)
     def VerifyVersionInfo(self, emu, argv, ctx={}):
         '''
         BOOL VerifyVersionInfo(

--- a/speakeasy/winenv/api/usermode/shell32.py
+++ b/speakeasy/winenv/api/usermode/shell32.py
@@ -96,7 +96,7 @@ class Shell32(api.ApiHandler):
 
         return 33
 
-    @apihook('IsUserAnAdmin', argc=0)
+    @apihook('IsUserAnAdmin', argc=0, ordinal=680)
     def IsUserAnAdmin(self, emu, argv, ctx={}):
         """
         BOOL IsUserAnAdmin();

--- a/speakeasy/winenv/defs/windows/windows.py
+++ b/speakeasy/winenv/defs/windows/windows.py
@@ -87,6 +87,15 @@ class GUID(EmuStruct):
         self.Data4 = ct.c_uint8 * 8
 
 
+class SID(EmuStruct):
+    def __init__(self, ptr_size, sub_authority_count):
+        super().__init__(ptr_size)
+        self.Revision = ct.c_uint8
+        self.SubAuthorityCount = ct.c_uint8
+        self.IdentifierAuthority = ct.c_uint8 * 6
+        self.SubAuthority = ct.c_uint32 * sub_authority_count
+
+
 class KSYSTEM_TIME(EmuStruct):
     def __init__(self, ptr_size):
         super().__init__(ptr_size)
@@ -315,3 +324,19 @@ def get_page_rights(define):
 
 def get_creation_flags(flags):
     return get_flag_defines(flags, prefix='CREATE_')
+
+
+def convert_sid_str_to_struct(ptr_size, sid_str):
+    sid_elements = sid_str.split('-')
+    sid_elements.remove('S')
+    sub_authority_count = len(sid_elements) - 2
+
+    sid_struct = SID(ptr_size, sub_authority_count)
+    sid_struct.Revision = int(sid_elements[0])
+    sid_struct.SubAuthorityCount = sub_authority_count
+    sid_struct.IdentifierAuthority = int(sid_elements[1]).to_bytes(6, 'big')
+    sub_authorities = sid_elements[2:]
+    for i in range(len(sub_authorities)):
+        sid_struct.SubAuthority[i] = int(sub_authorities[i])
+ 
+    return sid_struct


### PR DESCRIPTION
* Added a SID element to the user configuration
* Two additional SID-related API functions in `advapi32`
* Miscellaneous updates:
  * Added `TerminateThread` but did not fully implement
  * Updated calling convention for `kernel32.VerSetConditionMask` and `kernel32.VerifyVersionInfo`
  * Added ordinal value for `shell32.IsUserAnAdmin`