### PR TITLE
kernel32 resource API updates

### DIFF
--- a/speakeasy/windows/common.py
+++ b/speakeasy/windows/common.py
@@ -99,7 +99,7 @@ class PeParseException(Exception):
 
 class PeFile(pefile.PE):
     """
-    Class the will represent all PE files loaded into the emulator
+    Represents PE files loaded into the emulator
     """
     def __init__(self, path=None, data=None, imp_id=IMPORT_HOOK_ADDR,
                  imp_step=4, emu_path='', fast_load=False):
@@ -155,6 +155,15 @@ class PeFile(pefile.PE):
                     break
                 callbacks.append(ptr)
         return callbacks
+
+    def get_resource_dir_rva(self):
+        res_dir_rva = 0
+        for dd in self.OPTIONAL_HEADER.DATA_DIRECTORY:
+            if dd.name == "IMAGE_DIRECTORY_ENTRY_RESOURCE":
+                res_dir_rva = dd.VirtualAddress
+                break
+
+        return res_dir_rva
 
     def get_emu_path(self):
         """


### PR DESCRIPTION
* Fixed `FindResource`, `LoadResource`, `LockResource`, and `SizeofResource` implementations
  * Prior implementation did not return expected resource structures as they should exist in memory.
* Added `FreeResource` API
* Moved resource-related APIs next to each other in `kernel32.py` 

Binaries used to test updates include [this PMA sample](https://www.virustotal.com/gui/file/ae8a1c7eb64c42ea2a04f97523ebf0844c27029eb040d910048b680f884b9dce).