### PR TITLE
Modification to "MapViewOfFile" 

### DIFF
--- a/speakeasy/windows/fileman.py
+++ b/speakeasy/windows/fileman.py
@@ -45,6 +45,7 @@ class FileMap(object):
         self.backed_file = backed_file
         self.views = {}
         self.size = size
+        self.prot = prot
 
     def get_handle(self):
         hmap = FileMap.curr_handle
@@ -53,6 +54,9 @@ class FileMap(object):
 
     def get_name(self):
         return self.name
+
+    def get_prot(self):
+        return self.prot
 
     def get_backed_file(self):
         return self.backed_file


### PR DESCRIPTION
Currently the `MapViewOfFile`  maps the loaded file as a contiguous stream of bytes.

But this is not always the case: when a file is mapped and SEC_IMAGE protection flag has been set in the previous `CreateFileMapping`, the file is mapped as a PE file, with all the sections mapped accordingly. If this is not supported, following calls on the mapped memory can bring to unexpected results (this is often used by unhook functions).

I added:
- a `get_prot` method in the `FileMap` class to get the current protection
- support of mapping in `MapViewOfFile` 

