### PR TITLE
Minor fix in "VirtualAllocEx": added check to avoid null reference

### DIFF
--- a/speakeasy/winenv/api/usermode/kernel32.py
+++ b/speakeasy/winenv/api/usermode/kernel32.py
@@ -997,7 +997,7 @@ class Kernel32(api.ApiHandler):
 
         # Was this address already commited?
         mm = emu.get_address_map(lpAddress)
-        if mm and mm.get_tag().startswith(tag_prefix):
+        if mm and mm.get_tag() and mm.get_tag().startswith(tag_prefix):
             buf = lpAddress
         else:
 


### PR DESCRIPTION
When the tag is retrieved in `VirtualAllocEx` the `mm.get_tag()` is not checked before accessing the tag with `startswith` (as for example is done in `VirtualAlloc`).

This cause an error in some case:

```
if mm and mm.get_tag().startswith(tag_prefix):
AttributeError: 'NoneType' object has no attribute 'startswith'
```

This should fix this.