### PR TITLE
Adding stack_commit parameter for shellcode

### DIFF
--- a/speakeasy/speakeasy.py
+++ b/speakeasy/speakeasy.py
@@ -260,7 +260,7 @@ class Speakeasy(object):
         return self.emu.load_shellcode(fpath, arch, data=data)
 
     @check_init
-    def run_shellcode(self, sc_addr: int, offset=0) -> None:
+    def run_shellcode(self, sc_addr: int, stack_commit=0x4000, offset=0) -> None:
         """
         Run a previously loaded shellcode blob by address
 
@@ -271,7 +271,7 @@ class Speakeasy(object):
             None
         """
         self._init_hooks()
-        return self.emu.run_shellcode(sc_addr, offset=offset)
+        return self.emu.run_shellcode(sc_addr, stack_commit=stack_commit, offset=offset)
 
     @check_init
     def get_report(self) -> dict:

--- a/speakeasy/windows/win32.py
+++ b/speakeasy/windows/win32.py
@@ -495,7 +495,7 @@ class Win32Emulator(WindowsEmulator):
 
         return sc_addr
 
-    def run_shellcode(self, sc_addr, offset=0):
+    def run_shellcode(self, sc_addr, stack_commit=0x4000, offset=0):
         """
         Begin emulating position independent code (i.e. shellcode) to prepare for emulation
         """
@@ -508,8 +508,6 @@ class Win32Emulator(WindowsEmulator):
 
         if not target:
             raise Win32EmuError('Invalid shellcode address')
-
-        stack_commit = 0x4000
 
         self.stack_base, stack_addr = self.alloc_stack(stack_commit)
         self.set_func_args(self.stack_base, self.return_hook, 0x7000)


### PR DESCRIPTION
Provide parameter for adjusting the stack commit size when emulating shellcode payloads that require a stack size larger that 16384 bytes.