### PR TITLE
Added InitCommonControls - Under Comctl32.dll version 6.0 and later, …

### DIFF
--- a/speakeasy/winenv/api/usermode/comctl32.py
+++ b/speakeasy/winenv/api/usermode/comctl32.py
@@ -30,3 +30,12 @@ class Comctl32(api.ApiHandler):
         rv = True
 
         return rv
+
+    @apihook('InitCommonControls', argc=0)
+    def InitCommonControlsEx(self, emu, argv, ctx={}):
+        """
+        void InitCommonControls();
+        Under Comctl32.dll version 6.0 and later, InitCommonControls does nothing. Applications must explicitly register all common controls through InitCommonControlsEx.
+        """
+
+        return

--- a/speakeasy/winenv/api/usermode/user32.py
+++ b/speakeasy/winenv/api/usermode/user32.py
@@ -780,6 +780,28 @@ class User32(api.ApiHandler):
             rv = s + cw
         return rv
 
+    @apihook('CharPrev', argc=2)
+    def CharPrev(self, emu, argv, ctx={}):
+        '''
+        LPSTR CharPrev(
+            LPCSTR lpszStart,
+            LPCSTR lpszCurrent
+        );
+        '''
+        '''
+        Got this from wine.          
+        https://github.com/wine-mirror/wine/blob/a8c1d5c108fc57e4d78e9db126f395c89083a83d/dlls/kernelbase/string.c
+        '''
+        s,c = argv
+        cw = self.get_char_width(ctx)
+        while(s<c):
+            n  = s + cw
+            if (n>=c): 
+                break;
+            s = n;
+
+        return s
+
     @apihook('EnumWindows', argc=2)
     def EnumWindows(self, emu, argv, ctx={}):
         '''


### PR DESCRIPTION
…InitCommonControls does nothing. Applications must explicitly register all common controls through InitCommonControlsEx.

Added CharPrevA