### PR TITLE
Implementation of ShellExecuteEx

### DIFF
--- a/speakeasy/winenv/api/usermode/shell32.py
+++ b/speakeasy/winenv/api/usermode/shell32.py
@@ -108,8 +108,17 @@ class Shell32(api.ApiHandler):
         sei = shell32_defs.SHELLEXECUTEINFOA(emu.get_ptr_size())
         sei_struct = self.mem_cast(sei, lpShellExecuteInfo)
 
-        self.ShellExecute(emu,[ 0, sei_struct.lpVerb, sei_struct.lpFile,
-                          sei_struct.lpParameters, sei_struct.lpDirectory, 0], ctx)
+        self.ShellExecute(
+            emu,
+            [
+                0,
+                sei_struct.lpVerb,
+                sei_struct.lpFile,
+                sei_struct.lpParameters, sei_struct.lpDirectory,
+                0
+            ], 
+            ctx
+        )
         
         return True
         

--- a/speakeasy/winenv/api/usermode/shell32.py
+++ b/speakeasy/winenv/api/usermode/shell32.py
@@ -96,6 +96,23 @@ class Shell32(api.ApiHandler):
 
         return 33
 
+    @apihook('ShellExecuteEx', argc=1)
+    def ShellExecuteEx(self, emu, argv, ctx={}):
+        '''
+        BOOL ShellExecuteExA(
+            [in, out] SHELLEXECUTEINFOA *pExecInfo
+        );
+        '''
+        lpShellExecuteInfo, = argv
+
+        sei = shell32_defs.SHELLEXECUTEINFOA(emu.get_ptr_size())
+        sei_struct = self.mem_cast(sei, lpShellExecuteInfo)
+
+        self.ShellExecute(emu,[ 0, sei_struct.lpVerb, sei_struct.lpFile,
+                          sei_struct.lpParameters, sei_struct.lpDirectory, 0], ctx)
+        
+        return True
+        
     @apihook('IsUserAnAdmin', argc=0, ordinal=680)
     def IsUserAnAdmin(self, emu, argv, ctx={}):
         """

--- a/speakeasy/winenv/defs/windows/shell32.py
+++ b/speakeasy/winenv/defs/windows/shell32.py
@@ -1,4 +1,5 @@
-
+from speakeasy.struct import EmuStruct, Ptr
+import ctypes as ct
 
 CSIDL = {
     0x00: "CSIDL_DESKTOP",
@@ -63,3 +64,22 @@ CSIDL = {
     0x43: "CSIDL_SAMPLE_VIDEOS",
     0x45: "CSIDL_PHOTOALBUMS",
 }
+
+class SHELLEXECUTEINFOA(EmuStruct):
+    def __init__(self, ptr_size):
+        super().__init__(ptr_size)
+        self.cbSize = ct.c_uint32
+        self.fMask = ct.c_uint32
+        self.hwnd = Ptr
+        self.lpVerb = Ptr
+        self.lpFile = Ptr
+        self.lpParameters = Ptr
+        self.lpDirectory = Ptr
+        self.nShow = ct.c_int32
+        self.hInstApp = Ptr
+        self.lpIDList = Ptr
+        self.lpClass = Ptr
+        self.hkeyClass = Ptr
+        self.dwHotKey = ct.c_uint32
+        self.DummyUnionName = Ptr
+        self.handle = Ptr

--- a/speakeasy/winenv/defs/windows/shell32.py
+++ b/speakeasy/winenv/defs/windows/shell32.py
@@ -1,5 +1,6 @@
-from speakeasy.struct import EmuStruct, Ptr
 import ctypes as ct
+
+from speakeasy.struct import EmuStruct, Ptr
 
 CSIDL = {
     0x00: "CSIDL_DESKTOP",


### PR DESCRIPTION
I made this implementation of ShellExecuteEx (should work for both A and W variant):

- I implemented the structure in `speakeasy/winenv/defs/windows/shell32.py`
- the call to `ShellExecuteEx` parse the parameters and then call the existing `ShellExecute`. 
I did in this way to avoid to duplicate code, even I'm not sure if this the correct way. What do you think?

Feel free to reject it anyway ;-)
