### PR TITLE
Add setuptools to requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ lznt1
 unicorn==1.0.2
 jsonschema
 pycryptodome
+setuptools


### PR DESCRIPTION
Running `setup.py install` requires the presence of the `setuptools` pip package. Along with a fresh Python install, adding this entry to requirements.txt makes following the installation documentation work without trouble.

As an addendum, I would recommend checking if the Python version is in WindowsApps in the setup.py file, in which case to bail early. I've found that SetupTools wants to do modifications in the Python path, which it wouldn't have permission to the way the application is packaged. If welcomed, I would be willing to also implement this to make our PR more substantial.