### PR TITLE
Added missing read-only KUSER_SHARED_DATA mapping

### DIFF
--- a/speakeasy/windows/winemu.py
+++ b/speakeasy/windows/winemu.py
@@ -407,6 +407,11 @@ class WindowsEmulator(BinaryEmulator):
             self.mem_map(self.page_size, base=0xFFFFF78000000000,
                          tag='emu.struct.KUSER_SHARED_DATA')
 
+        # This is a read-only address for KUSER_SHARED_DATA,
+        # and this is the same address for 32-bit and 64-bit.
+        self.mem_map(self.page_size, base=0x7FFE0000,
+            tag='emu.struct.KUSER_SHARED_DATA')
+
     def resume(self, addr, count=-1):
         """
         Resume emulation at the specified address.


### PR DESCRIPTION
KUSER_SHARED_DATA has a read-only memory mapping at the fixed address 0x7ffe0000, which is sometimes accessed directly by malware.

Ideally this should be a read-only copy of the actual KUSER_SHARED_DATA structure (that is already mapped a few lines above), but since we are not actually filling this structure with credible values, just having this mapped in memory will work for now, and will get rid of some invalid memory read errors to fix emulation of certain malware binaries.

References:
- https://labs.jumpsec.com/abusing-shareduserdata-for-defense-evasion-and-exploitation-2/
- https://medium.com/@boutnaru/the-windows-concept-journey-shareduserdata-kuser-shared-data-78e980d628e3
