### PR TITLE
Fix shellcode emulation: use memory-mapped image for decoy PEs

### DIFF
--- a/speakeasy/windows/objman.py
+++ b/speakeasy/windows/objman.py
@@ -477,6 +477,7 @@ class Process(KernelObject):
             list_entry = self.address + 0x188
             self.emu.mem_write(list_entry, list_entry.to_bytes(8, "little"))
             self.emu.mem_write(list_entry + 8, list_entry.to_bytes(8, "little"))
+        self.ldr_entries: list[LdrDataTableEntry] = []
         self.name: str = name
         self.base: int = base
         self.pid: int = self.id

--- a/tests/test.json
+++ b/tests/test.json
@@ -297,14 +297,14 @@
 
         "user_modules": [
                 {
-                    "name": "kernel32",
-                    "base_addr": "0x77000000",
-                    "path": "C:\\Windows\\system32\\kernel32.dll"
-                },
-                {
                     "name": "ntdll",
                     "base_addr": "0x7C000000",
                     "path": "C:\\Windows\\system32\\ntdll.dll"
+                },
+                {
+                    "name": "kernel32",
+                    "base_addr": "0x77000000",
+                    "path": "C:\\Windows\\system32\\kernel32.dll"
                 },
 
                 {


### PR DESCRIPTION
## Summary

- **Root cause**: `ApiModuleLoader` wrote raw PE file bytes into emulated memory, but PE sections have different file offsets vs virtual addresses. Shellcode walking the PEB `InInitializationOrderModuleList` to find kernel32 and parse its export directory would read garbage data because `.edata` was at its file offset rather than its virtual address.
- **Fix**: Use `pefile.get_memory_mapped_image()` so sections are placed at their correct virtual addresses, matching how Windows actually loads DLLs.
- **Bonus fix**: `Process.ldr_entries` was a shared class-level mutable list (classic Python gotcha) instead of per-instance, causing cross-test contamination. Moved to `__init__`.
- **Config fix**: Test config `test.json` now lists ntdll before kernel32, matching the default config order.

## Test plan

- [x] New `test_peb_shellcode.py` with two tests:
  - PEB walk shellcode resolves `WinExec` from kernel32 via `InInitializationOrderModuleList`
  - Same shellcode succeeds even when config has kernel32 before ntdll (verifying `_ordered_peb_modules()`)
- [x] All existing tests pass (47 passed, 1 skipped; 2 pre-existing failures from missing capa-testfiles)

Closes #45

🤖 Generated with [Claude Code](https://claude.com/claude-code)