### PR TITLE
fix: re-enable code hook after import dispatch

### DIFF
--- a/speakeasy/windows/winemu.py
+++ b/speakeasy/windows/winemu.py
@@ -1693,6 +1693,12 @@ class WindowsEmulator(BinaryEmulator):
             if not self.run_complete and ret == oret and pc == opc:
                 self.do_call_return(argc, ret, rv, conv=conv)
 
+            # Re-enable the code hook so the next instruction can unmap the
+            # sentinel range again. Otherwise adjacent sentinel calls may
+            # execute bytes in EMU_RESERVED instead of trapping as imports.
+            if not self.run_complete:
+                self.enable_code_hook()
+
         else:
             # Unsupported API: no speakeasy handler exists, so argc/call_conv
             # must come from the hook itself. Only the last registered hook
@@ -1719,6 +1725,8 @@ class WindowsEmulator(BinaryEmulator):
                 ret = self.get_ret_address()
                 self.log_api(call_pc, imp_api, rv, argv)
                 self.do_call_return(hook.argc, ret, rv, conv=hook.call_conv)
+                if not self.run_complete:
+                    self.enable_code_hook()
                 return
             elif self.config.modules.functions_always_exist:
                 imp_api = f"{dll}.{name}"
@@ -1729,6 +1737,8 @@ class WindowsEmulator(BinaryEmulator):
                 ret = self.get_ret_address()
                 self.log_api(call_pc, imp_api, rv, argv)
                 self.do_call_return(argc, ret, rv, conv=conv)
+                if not self.run_complete:
+                    self.enable_code_hook()
                 return
 
             run = self.get_current_run()


### PR DESCRIPTION
## Summary

Speakeasy v2 can leave the import-sentinel reserved range mapped after returning from an API/import dispatch. When the next sentinel address is executed, Unicorn may treat bytes in the reserved `0xfeee...` range as normal executable code instead of trapping back into Speakeasy's import handler.

## Crash record

The failure I observed ended with:

```text
invalid_fetch
pc = 0xfeee2fd2
instr = add byte ptr [rax], al
fetch address = 0xfeee3000
address_region = unknown [0xfeee3000-0xfeee3fff], prot=rwx
thread_id = 1076
process_id = 1056
```

Immediately before the crash, execution had already gone through dynamically resolved import sentinels in the `0xfeedf...` range. The crash PC being inside the reserved sentinel area suggests the reserved range was still mapped and executable when control reached a later sentinel.

## Why this looks wrong

The sentinel range should normally be used as a trap mechanism for imported API calls. A call into a sentinel address should cause an unmapped-fetch/import-dispatch path, not execute bytes in the reserved region as real instructions.

In this failing run, the emulator instead executed inside the reserved range until it reached the boundary at `0xfeee3000`, where the invalid fetch occurred.

## Suspected fix

Re-enabling the code hook after successful API/import dispatch appears to restore the expected behavior. With that change, the next instruction can pass through the code-hook path and the sentinel range can be unmapped again before a following sentinel call.

A PR with the proposed fix is here:

https://github.com/mandiant/speakeasy/pull/290

## Validation

With the proposed patch applied:

```text
uvx ruff check          -> passed
uvx ruff format --check -> passed
python -m pytest tests/ -> 90 passed, 1 skipped
```

The same packed-PE emulation path also completed without the `0xfeee3000` invalid fetch:

```text
ret_val = 0x0
error = None
events = 516
```

Thanks for maintaining Speakeasy and for reviewing this report.
