### PR TITLE
Add InterlockedExchangeAdd to kernel32 API stubs

### DIFF
--- a/speakeasy/winenv/api/usermode/kernel32.py
+++ b/speakeasy/winenv/api/usermode/kernel32.py
@@ -2555,6 +2555,20 @@ class Kernel32(api.ApiHandler):
 
         return ival
 
+    @apihook("InterlockedExchangeAdd", argc=2)
+    def InterlockedExchangeAdd(self, emu, argv, ctx: api.ApiContext = None):
+        """
+        LONG InterlockedExchangeAdd(
+            LONG volatile *Addend,
+            LONG          Value
+        );
+        """
+        Addend, Value = argv
+        old = int.from_bytes(self.mem_read(Addend, 4), "little")
+        new = (old + Value) & 0xFFFFFFFF
+        self.mem_write(Addend, new.to_bytes(4, "little"))
+        return old
+
     @apihook("GetCommandLine", argc=0)
     def GetCommandLine(self, emu, argv, ctx: api.ApiContext = None):
         """

--- a/speakeasy/winenv/api/usermode/kernel32.py
+++ b/speakeasy/winenv/api/usermode/kernel32.py
@@ -2565,7 +2565,7 @@ class Kernel32(api.ApiHandler):
         """
         Addend, Value = argv
         old = int.from_bytes(self.mem_read(Addend, 4), "little")
-        new = (old + Value) & 0xFFFFFFFF
+        new = (old + (Value & 0xFFFFFFFF)) & 0xFFFFFFFF
         self.mem_write(Addend, new.to_bytes(4, "little"))
         return old
 


### PR DESCRIPTION
`InterlockedExchangeAdd` is a commonly used `kernel32` export for atomic
addition (CRT, COM, and many third-party runtimes call it). Without a stub,
emulation hits an `unsupported_api` error during `DLL_PROCESS_ATTACH` and
terminates before any subsequent API calls can be captured.

Implementation reads the current DWORD at `Addend`, adds `Value`, writes
the result back, and returns the original value — matching the documented
Windows behaviour.

Placed alongside the existing `InterlockedIncrement` /
`InterlockedDecrement` stubs in `kernel32.py`.
