### PR TITLE
Rewrite GDB server in Python

### DIFF
--- a/doc/cli-execution-controls.md
+++ b/doc/cli-execution-controls.md
@@ -34,6 +34,7 @@ speakeasy -t shellcode.bin \
 Primary flags:
 - `--verbose`: DEBUG logging
 - `--gdb`: start GDB stub and pause before first instruction
+- `--gdb-host`: GDB stub bind host (default `127.0.0.1`)
 - `--gdb-port`: GDB stub port
 
 Notes:

--- a/doc/cli-help-showboat.md
+++ b/doc/cli-help-showboat.md
@@ -13,7 +13,8 @@ Captured from the current source tree to show the full runtime and schema-derive
 usage: cli.py [-h] [-t TARGET] [-o OUTPUT] [--argv ARGV] [-c CONFIG]
               [--dump-default-config] [--raw] [--raw-offset RAW_OFFSET]
               [--arch ARCH] [--dropped-files-path DROPPED_FILES_PATH] [-k] [--no-mp] [-v]
-              [--gdb] [--gdb-port GDB_PORT] [-V VOLUMES] [--timeout TIMEOUT]
+              [--gdb] [--gdb-host GDB_HOST] [--gdb-port GDB_PORT]
+              [-V VOLUMES] [--timeout TIMEOUT]
               [--max-api-count MAX_API_COUNT]
               [--max-instructions MAX_INSTRUCTIONS]
               [--analysis-memory-tracing | --no-analysis-memory-tracing]
@@ -66,6 +67,7 @@ options:
   -v, --verbose         Enable verbose (DEBUG) logging
   --gdb                 Enable GDB server stub (pauses before first
                         instruction)
+  --gdb-host GDB_HOST   GDB server bind host (default: 127.0.0.1)
   --gdb-port GDB_PORT   GDB server port (default: 1234)
   -V, --volume VOLUMES  Mount a host path into the emulated filesystem
                         (host_path:guest_path). May be repeated.

--- a/doc/cli-reference.md
+++ b/doc/cli-reference.md
@@ -35,6 +35,7 @@ These flags are not generated from the config schema.
 - `--no-mp`: run in current process instead of worker process
 - `-v, --verbose`: DEBUG logging
 - `--gdb`: enable GDB stub and pause before first instruction
+- `--gdb-host`: GDB stub bind host (default `127.0.0.1`)
 - `--gdb-port`: GDB stub port (default `1234`)
 - `-V, --volume`: host_path:guest_path mapping (repeatable)
 

--- a/doc/gdb-examples.md
+++ b/doc/gdb-examples.md
@@ -5,10 +5,10 @@
 
 Speakeasy supports interactive debugging via the GDB Remote Serial Protocol. When you pass `--gdb`, the emulator pauses before the first instruction and waits for a GDB client to connect. You can then set breakpoints, inspect registers and memory, single-step, and continue execution — all through a standard GDB interface.
 
-Install the optional GDB dependency:
+GDB support is included in the standard installation:
 
 ```
-pip install speakeasy-emulator[gdb]
+pip install speakeasy-emulator
 ```
 
 ### Debugging a 32-bit DLL
@@ -205,7 +205,7 @@ The GDB server can also be enabled when using speakeasy as a Python library. Pas
 ```python
 import speakeasy
 
-se = speakeasy.Speakeasy(gdb_port=1234)
+se = speakeasy.Speakeasy(gdb_port=1234, gdb_host="127.0.0.1")
 module = se.load_module("sample.dll")
 # Blocks here waiting for GDB to connect, then emulates under GDB control
 se.run_module(module)

--- a/doc/gdb-examples.md
+++ b/doc/gdb-examples.md
@@ -5,12 +5,6 @@
 
 Speakeasy supports interactive debugging via the GDB Remote Serial Protocol. When you pass `--gdb`, the emulator pauses before the first instruction and waits for a GDB client to connect. You can then set breakpoints, inspect registers and memory, single-step, and continue execution — all through a standard GDB interface.
 
-GDB support is included in the standard installation:
-
-```
-pip install speakeasy-emulator
-```
-
 ### Debugging a 32-bit DLL
 
 Start speakeasy with `--gdb` on a sample DLL. It will pause before the first instruction and wait for GDB to connect. In a second terminal, connect with `gdb` (or `gdb-multiarch`) and set the architecture to `i386`:

--- a/doc/gdb.md
+++ b/doc/gdb.md
@@ -2,24 +2,6 @@
 
 Speakeasy supports interactive debugging of emulated binaries via the GDB Remote Serial Protocol. When enabled, the emulator pauses before the first instruction and waits for a GDB client to connect. You can then set breakpoints, inspect registers and memory, single-step, and continue execution — all through a standard GDB interface.
 
-The GDB server is implemented directly by Speakeasy and has no optional runtime dependencies.
-
----
-
-## Installation
-
-GDB support is included in a normal installation:
-
-```console
-pip install speakeasy-emulator
-```
-
-Or, when installing from source:
-
-```console
-pip install -e .
-```
-
 ---
 
 ## Quick Start

--- a/doc/gdb.md
+++ b/doc/gdb.md
@@ -2,22 +2,22 @@
 
 Speakeasy supports interactive debugging of emulated binaries via the GDB Remote Serial Protocol. When enabled, the emulator pauses before the first instruction and waits for a GDB client to connect. You can then set breakpoints, inspect registers and memory, single-step, and continue execution — all through a standard GDB interface.
 
-This uses the [udbserver](https://github.com/bet4it/udbserver) library, which hooks directly into the Unicorn emulation engine.
+The GDB server is implemented directly by Speakeasy and has no optional runtime dependencies.
 
 ---
 
 ## Installation
 
-The GDB server support is an optional dependency. Install it with:
+GDB support is included in a normal installation:
 
 ```console
-pip install speakeasy-emulator[gdb]
+pip install speakeasy-emulator
 ```
 
-Or if installing from source:
+Or, when installing from source:
 
 ```console
-pip install -e ".[gdb]"
+pip install -e .
 ```
 
 ---
@@ -33,7 +33,7 @@ speakeasy -t sample.exe --gdb
 This starts the GDB server on the default port (1234). Speakeasy will print a message and block until a GDB client connects:
 
 ```
-GDB server listening on port 1234, waiting for connection...
+Native GDB server listening on 127.0.0.1:1234, waiting for connection...
 ```
 
 To use a different port:
@@ -42,7 +42,15 @@ To use a different port:
 speakeasy -t sample.exe --gdb --gdb-port 9999
 ```
 
-> **Note:** `--gdb` automatically enables `--no-mp` (in-process emulation). This is required because the GDB server hooks are bound to a specific Unicorn engine instance and cannot cross process boundaries.
+The server binds to loopback by default. To allow a debugger on another machine to connect, explicitly choose a bind address:
+
+```console
+speakeasy -t sample.exe --gdb --gdb-host 0.0.0.0 --gdb-port 9999
+```
+
+> **Warning:** GDB RSP has no authentication and permits target memory and register modification. Only use a non-loopback `--gdb-host` on a trusted network or behind an appropriate firewall/tunnel.
+>
+> `--gdb` automatically enables `--no-mp` because the server must remain attached to the same Unicorn instance.
 
 ### 2. Connect with GDB
 
@@ -147,7 +155,7 @@ The GDB server can also be enabled when using speakeasy as a library:
 ```python
 import speakeasy
 
-se = speakeasy.Speakeasy(gdb_port=1234)
+se = speakeasy.Speakeasy(gdb_port=1234, gdb_host="127.0.0.1")
 module = se.load_module("sample.dll")
 # This will block waiting for GDB to connect before emulating
 se.run_module(module)
@@ -157,23 +165,43 @@ se.run_module(module)
 
 ## How It Works
 
-The GDB integration uses `udbserver`, which installs Unicorn hooks for breakpoints, watchpoints, and single-stepping. When `gdb_port` is set:
+Speakeasy implements the all-stop GDB Remote Serial Protocol directly. The server provides register and memory access, software and hardware breakpoints, watchpoints, single-step, asynchronous Ctrl-C pause, and the Windows process metadata used by IDA:
 
-1. Speakeasy loads the binary and sets up all its emulation hooks normally
-2. Speakeasy initializes the first run context (stack/arguments/registers), including setting PC to the run entry point
-3. Before the first `emu_start()` call, `udbserver()` is called with `start_addr=0`
-4. This blocks on a TCP accept, waiting for a GDB client
-5. The GDB client connects, sets breakpoints, and issues `continue`
-6. `udbserver()` returns and emulation proceeds under GDB control
-7. The udbserver hooks persist across all emulation runs (DllMain, exports, etc.)
+- `qXfer:libraries:read` returns all mapped Speakeasy PE modules
+- `qXfer:exec-file:read` returns the emulated executable path
+- `qXfer:threads:read`, `qfThreadInfo`, and `qGetTIBAddr` describe the active emulated thread
+- `qXfer:features:read` reports a register layout matching the emulated architecture
+- `qXfer:memory-map:read` reports Unicorn's mapped memory regions
+- `vCont`, legacy resume packets, register/memory writes, detach, and process exit are supported
+
+A socket reader handles RSP framing and can stop Unicorn asynchronously when it receives Ctrl-C. Breakpoint and watchpoint hooks only record a stop reason and stop Unicorn; protocol processing happens after `emu_start()` returns, rather than from inside a Unicorn callback.
 
 ---
 
+## Supported protocol subset
+
+The server implements the all-stop RSP subset exercised by GDB and IDA:
+
+| Area | Packets |
+|---|---|
+| Transport | checksums, ACK/NACK retransmission, `QStartNoAckMode`, binary escaping, raw Ctrl-C |
+| Target discovery | `qSupported`, `qXfer:features:read`, `qXfer:memory-map:read` |
+| Windows metadata | `qXfer:libraries:read`, `qXfer:exec-file:read`, `qXfer:threads:read`, `qGetTIBAddr` |
+| Thread selection | `qC`, `qfThreadInfo`, `qsThreadInfo`, `H`, `T` for the synthetic active thread |
+| Registers | `g`, `G`, `p`, `P` |
+| Memory | `m`, `M`, `X` |
+| Breakpoints | `Z0`/`z0`, `Z1`/`z1`, and read/write/access watchpoints |
+| Execution | `c`, `s`, `vCont`, asynchronous Ctrl-C, `?` |
+| Lifecycle | `D`, `k`, and `Wxx` exit replies |
+
+Unsupported optional packets receive an empty response as required by RSP. Non-stop mode, multiprocess mode, reverse execution, and remote file I/O are not advertised.
+
 ## Limitations
 
-- one session per process: udbserver uses global state internally, so only one GDB server can be active per process
-- breakpoints persist across runs: Speakeasy executes multiple runs (for example DllMain and exports), and breakpoints remain active across run boundaries
-- platform support: if your platform is unsupported by udbserver binaries, `--gdb` fails with an import error
+- one debugger client can connect to a Speakeasy instance
+- Speakeasy models Windows thread objects but executes one Unicorn CPU context at a time; the server therefore presents the currently active execution context as one synthetic GDB thread
+- breakpoints persist across runs: Speakeasy executes multiple runs (for example TLS callbacks, the module entry point, and exports)
+- reverse execution, non-stop mode, and multiprocess RSP are not implemented
 
 ## Related docs
 

--- a/doc/install.md
+++ b/doc/install.md
@@ -8,8 +8,6 @@ Speakeasy requires Python 3.10+.
 python3 -m pip install speakeasy-emulator
 ```
 
-GDB remote debugging support is included in the standard package.
-
 Verify installation:
 
 ```console

--- a/doc/install.md
+++ b/doc/install.md
@@ -8,11 +8,7 @@ Speakeasy requires Python 3.10+.
 python3 -m pip install speakeasy-emulator
 ```
 
-Optional GDB support:
-
-```console
-python3 -m pip install "speakeasy-emulator[gdb]"
-```
+GDB remote debugging support is included in the standard package.
 
 Verify installation:
 
@@ -26,12 +22,6 @@ speakeasy -h
 git clone https://github.com/mandiant/speakeasy.git
 cd speakeasy
 python3 -m pip install -e ".[dev]"
-```
-
-Optional GDB support from source:
-
-```console
-python3 -m pip install -e ".[dev,gdb]"
 ```
 
 ## Run in Docker

--- a/doc/library.md
+++ b/doc/library.md
@@ -36,7 +36,7 @@ se.shutdown()
 - pass `config=` to control environment and analysis
 - pass `argv=` to populate emulated process arguments
 - pass `volumes=` to mount host paths into emulated filesystem
-- pass `gdb_port=` to block for GDB attach before execution
+- pass `gdb_port=` to block for GDB attach before execution; `gdb_host=` controls the bind address and defaults to `127.0.0.1`
 
 For runnable scripts, see [../examples](../examples/).
 

--- a/doc/speakeasy2-walkthrough.md
+++ b/doc/speakeasy2-walkthrough.md
@@ -235,7 +235,7 @@ How to read this: `tid` changes on each queued run (`1076 -> 1200 -> 1212`), whi
 
 ## Interactive debugging with --gdb
 
-Speakeasy now provides a built-in GDB remote stub via udbserver and can pause before first instruction until a client connects. The flow is available from both CLI and library usage, with explicit port selection. This enables interactive stepping, breakpoints, and memory/register inspection during emulation.
+Speakeasy provides a native GDB remote stub and can pause before the first instruction until a client connects. The flow is available from both CLI and library usage, with explicit port selection. This enables interactive pausing, stepping, breakpoints, watchpoints, and memory/register inspection during emulation.
 
 Quick way to use it: in terminal 1 run `speakeasy -t sample.dll --gdb --gdb-port 1234` and wait for the listener message; Speakeasy will force `--no-mp` automatically so the stub stays attached to the same Unicorn instance. In terminal 2 run `gdb-multiarch`, then `set architecture i386` (or `i386:x86-64` for 64-bit), and `target remote localhost:1234`; from there standard commands like `info registers`, `x/10i $pc`, `break *0x...`, `stepi`, and `continue` work as expected.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,6 @@ dev = [
     "ruff",
     "mypy",
 ]
-gdb = ["udbserver>=0.2.1"]
 
 [project.urls]
 Homepage = "https://github.com/mandiant/speakeasy"

--- a/speakeasy/cli.py
+++ b/speakeasy/cli.py
@@ -47,13 +47,20 @@ def emulate_binary(
     emulate_children=False,
     verbose=False,
     gdb_port=None,
+    gdb_host="127.0.0.1",
 ):
     setup_logging(verbose)
 
     report = None
     se = None
     try:
-        se = Speakeasy(config=cfg, argv=argv, exit_event=exit_event, gdb_port=gdb_port)
+        se = Speakeasy(
+            config=cfg,
+            argv=argv,
+            exit_event=exit_event,
+            gdb_port=gdb_port,
+            gdb_host=gdb_host,
+        )
         if do_raw:
             arch = arch.lower()
             if arch == "x86":
@@ -101,13 +108,13 @@ def run_main(parser: argparse.ArgumentParser, args: argparse.Namespace, config_s
     argv = shlex.split(args.argv) if args.argv else []
     verbose = args.verbose
     gdb_port = args.gdb_port if args.gdb else None
+    gdb_host = args.gdb_host
 
     setup_logging(verbose)
 
     if args.gdb and not args.no_mp:
         args.no_mp = True
         logger.info("--gdb requires --no-mp mode; enabling automatically")
-
     cfg = get_default_config_dict()
 
     if config_path:
@@ -154,6 +161,7 @@ def run_main(parser: argparse.ArgumentParser, args: argparse.Namespace, config_s
             emulate_children=emulate_children,
             verbose=verbose,
             gdb_port=gdb_port,
+            gdb_host=gdb_host,
         )
         report = q.get()
     else:
@@ -175,6 +183,7 @@ def run_main(parser: argparse.ArgumentParser, args: argparse.Namespace, config_s
                 "emulate_children": emulate_children,
                 "verbose": verbose,
                 "gdb_port": gdb_port,
+                "gdb_host": gdb_host,
             },
         )
         p.start()
@@ -308,6 +317,14 @@ def main():
         dest="gdb",
         required=False,
         help="Enable GDB server stub (pauses before first instruction)",
+    )
+    parser.add_argument(
+        "--gdb-host",
+        action="store",
+        dest="gdb_host",
+        default="127.0.0.1",
+        required=False,
+        help="GDB server bind host (default: 127.0.0.1)",
     )
     parser.add_argument(
         "--gdb-port",

--- a/speakeasy/engines/unicorn_eng.py
+++ b/speakeasy/engines/unicorn_eng.py
@@ -271,7 +271,13 @@ class EmuEngine:
             return hook.disable()
 
     def hook_remove(self, hid):
-        return self.emu.hook_del(hid)  # type: ignore[union-attr]
+        if hid not in self._callbacks:
+            return self.emu.hook_del(hid)  # type: ignore[union-attr]
+
+        status = _uc.uc_hook_del(self.emu._uch, uc_hook_h(hid))  # type: ignore[union-attr]
+        if status != uc.UC_ERR_OK:
+            raise uc.UcError(status)
+        self._callbacks.pop(hid, None)
 
     def close(self):
         if self.emu is None:

--- a/speakeasy/gdb.py
+++ b/speakeasy/gdb.py
@@ -1,0 +1,695 @@
+"""Speakeasy-native GDB Remote Serial Protocol server.
+
+The server deliberately implements the all-stop subset used by GDB and IDA.
+Target operations are performed by the emulation thread; a small reader thread
+only parses transport packets and interrupts a running Unicorn instance on
+Ctrl-C.
+"""
+
+from __future__ import annotations
+
+import html
+import logging
+import queue
+import socket
+import threading
+from dataclasses import dataclass
+from typing import Any
+
+import unicorn.x86_const as ux
+
+from speakeasy.winenv import arch
+
+logger = logging.getLogger(__name__)
+
+_PACKET_SIZE = 0x4000
+
+
+def _rsp_packet(payload: bytes) -> bytes:
+    return b"$" + payload + f"#{sum(payload) & 0xFF:02x}".encode("ascii")
+
+
+def _rsp_escape(data: bytes) -> bytes:
+    result = bytearray()
+    for value in data:
+        if value in b"$#}*":
+            result.extend((ord("}"), value ^ 0x20))
+        else:
+            result.append(value)
+    return bytes(result)
+
+
+def _rsp_unescape(data: bytes) -> bytes:
+    result = bytearray()
+    index = 0
+    while index < len(data):
+        if data[index] == ord("}") and index + 1 < len(data):
+            result.append(data[index + 1] ^ 0x20)
+            index += 2
+        else:
+            result.append(data[index])
+            index += 1
+    return bytes(result)
+
+
+@dataclass(frozen=True)
+class ResumeAction:
+    step: bool = False
+    detach: bool = False
+    kill: bool = False
+
+
+@dataclass(frozen=True)
+class StopReason:
+    signal: int = 5
+    kind: str = ""
+    address: int | None = None
+
+
+@dataclass(frozen=True)
+class RegisterInfo:
+    name: str
+    unicorn_id: int | None
+    size: int
+    group: str = ""
+
+
+class GdbServer:
+    """An all-stop RSP server backed directly by a WindowsEmulator."""
+
+    def __init__(self, emu: Any, port: int, host: str = "127.0.0.1"):
+        self.emu = emu
+        self.host = host
+        self.port = port
+        self._listener: socket.socket | None = None
+        self._client: socket.socket | None = None
+        self._reader: threading.Thread | None = None
+        self._commands: queue.Queue[bytes | None] = queue.Queue()
+        self._send_lock = threading.Lock()
+        self._state_lock = threading.Lock()
+        self._closed = threading.Event()
+        self._no_ack = False
+        self._last_packet: bytes | None = None
+        self._running = False
+        self._stop_reason = StopReason()
+        self._stop_pending = False
+        self._resume_from_breakpoint: int | None = None
+        self._exec_breakpoints: dict[tuple[int, int], int] = {}
+        self._read_watchpoints: dict[tuple[int, int], int] = {}
+        self._write_watchpoints: dict[tuple[int, int], int] = {}
+        self._registers = self._make_registers()
+        self._hooks: list[Any] = []
+
+    # ------------------------------------------------------------------
+    # Transport
+
+    def start(self) -> None:
+        if self.host not in ("127.0.0.1", "localhost"):
+            logger.warning("GDB RSP is unauthenticated; exposing it on %s permits target modification", self.host)
+        listener = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        listener.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        listener.bind((self.host, self.port))
+        listener.listen(1)
+        self._listener = listener
+        logger.info("Native GDB server listening on %s:%d, waiting for connection...", self.host, self.port)
+        client, address = listener.accept()
+        self._client = client
+        logger.info("GDB client connected from %s:%d", *address[:2])
+        self._install_hooks()
+        self._reader = threading.Thread(target=self._read_loop, name="speakeasy-gdb-reader", daemon=True)
+        self._reader.start()
+
+    def notify_exit(self, code: int) -> None:
+        if not self._closed.is_set():
+            try:
+                self._reply(f"W{code & 0xFF:02x}".encode("ascii"))
+            except OSError:
+                pass
+
+    def close(self) -> None:
+        self._closed.set()
+        for sock in (self._client, self._listener):
+            if sock is not None:
+                try:
+                    sock.shutdown(socket.SHUT_RDWR)
+                except OSError:
+                    pass
+                try:
+                    sock.close()
+                except OSError:
+                    pass
+        for hook in self._hooks:
+            try:
+                hook.disable()
+            except Exception:
+                pass
+
+    @staticmethod
+    def _extract_packet(buffer: bytearray) -> tuple[bytes, bytes, bool] | None:
+        if not buffer or buffer[0] != ord("$"):
+            return None
+        marker = buffer.find(b"#", 1)
+        if marker < 0 or len(buffer) < marker + 3:
+            return None
+        raw = bytes(buffer[: marker + 3])
+        encoded = bytes(buffer[1:marker])
+        try:
+            checksum = int(buffer[marker + 1 : marker + 3], 16)
+            valid = len(encoded) <= _PACKET_SIZE and not encoded.endswith(b"}") and checksum == (sum(encoded) & 0xFF)
+        except ValueError:
+            valid = False
+        del buffer[: marker + 3]
+        return raw, _rsp_unescape(encoded), valid
+
+    def _read_loop(self) -> None:
+        assert self._client is not None
+        buffer = bytearray()
+        try:
+            while not self._closed.is_set():
+                data = self._client.recv(65536)
+                if not data:
+                    break
+                buffer.extend(data)
+                while buffer:
+                    value = buffer[0]
+                    if value == 3:
+                        del buffer[:1]
+                        self._interrupt()
+                        continue
+                    if value in (ord("+"), ord("-")):
+                        del buffer[:1]
+                        if value == ord("-") and self._last_packet is not None:
+                            self._send_raw(self._last_packet)
+                        continue
+                    if value != ord("$"):
+                        del buffer[:1]
+                        continue
+                    packet = self._extract_packet(buffer)
+                    if packet is None:
+                        break
+                    _raw, payload, valid = packet
+                    if not valid:
+                        if not self._no_ack:
+                            self._send_raw(b"-")
+                        continue
+                    if not self._no_ack:
+                        self._send_raw(b"+")
+                    self._commands.put(payload)
+                if len(buffer) > _PACKET_SIZE + 4:
+                    logger.warning("Closing GDB connection after oversized or incomplete RSP packet")
+                    break
+        except OSError:
+            pass
+        finally:
+            self._commands.put(None)
+
+    def _send_raw(self, data: bytes) -> None:
+        if self._client is None:
+            return
+        with self._send_lock:
+            self._client.sendall(data)
+
+    def _reply(self, payload: bytes, *, binary: bool = False) -> None:
+        if binary:
+            payload = payload[:1] + _rsp_escape(payload[1:])
+        packet = _rsp_packet(payload)
+        self._last_packet = packet
+        self._send_raw(packet)
+
+    # ------------------------------------------------------------------
+    # Execution lifecycle
+
+    def command_loop(self, reason: StopReason | None = None) -> ResumeAction:
+        if reason is not None:
+            self._stop_reason = reason
+            self._reply(self._stop_reply(reason))
+        with self._state_lock:
+            self._running = False
+            self._stop_pending = False
+
+        while not self._closed.is_set():
+            payload = self._commands.get()
+            if payload is None:
+                return ResumeAction(detach=True)
+            action = self._handle_command(payload)
+            if action is not None:
+                return action
+        return ResumeAction(detach=True)
+
+    def begin_run(self, action: ResumeAction) -> None:
+        with self._state_lock:
+            self._running = True
+            self._stop_pending = False
+            self._stop_reason = StopReason()
+            pc = self.emu.get_pc()
+            at_breakpoint = any(begin <= pc < begin + size for begin, size in self._exec_breakpoints)
+            self._resume_from_breakpoint = pc if at_breakpoint else None
+
+    def finish_run(self, action: ResumeAction) -> StopReason | None:
+        with self._state_lock:
+            self._running = False
+            if self._stop_pending:
+                return self._stop_reason
+        if action.step:
+            return StopReason(kind="step")
+        return None
+
+    def _request_stop(self, reason: StopReason) -> None:
+        with self._state_lock:
+            if not self._running or self._stop_pending:
+                return
+            self._stop_reason = reason
+            self._stop_pending = True
+        if self.emu.emu_eng is not None:
+            self.emu.emu_eng.stop()
+
+    def _interrupt(self) -> None:
+        with self._state_lock:
+            running = self._running
+        if running:
+            self._request_stop(StopReason(signal=2, kind="interrupt"))
+        else:
+            self._commands.put(b"?")
+
+    def _install_hooks(self) -> None:
+        self._hooks.extend(
+            (
+                self.emu.add_code_hook(self._on_code),
+                self.emu.add_mem_read_hook(self._on_read),
+                self.emu.add_mem_write_hook(self._on_write),
+            )
+        )
+
+    def _on_code(self, _emu: Any, address: int, _size: int) -> bool:
+        if self._resume_from_breakpoint == address:
+            self._resume_from_breakpoint = None
+            return True
+        for (begin, size), bp_type in tuple(self._exec_breakpoints.items()):
+            if begin <= address < begin + size:
+                kind = "swbreak" if bp_type == 0 else "hwbreak"
+                self._request_stop(StopReason(kind=kind, address=address))
+                break
+        return True
+
+    def _on_read(self, _emu: Any, _access: int, address: int, size: int, _value: int) -> bool:
+        if self._overlaps_watchpoint(self._read_watchpoints, address, size):
+            self._request_stop(StopReason(kind="rwatch", address=address))
+        return True
+
+    def _on_write(self, _emu: Any, _access: int, address: int, size: int, _value: int) -> bool:
+        if self._overlaps_watchpoint(self._write_watchpoints, address, size):
+            self._request_stop(StopReason(kind="watch", address=address))
+        return True
+
+    @staticmethod
+    def _overlaps_watchpoint(watchpoints: dict[tuple[int, int], int], address: int, size: int) -> bool:
+        end = address + size
+        return any(begin < end and address < begin + length for begin, length in watchpoints)
+
+    # ------------------------------------------------------------------
+    # Commands
+
+    def _handle_command(self, payload: bytes) -> ResumeAction | None:
+        if payload.startswith(b"qSupported"):
+            self._reply(
+                b"PacketSize=4000;qXfer:features:read+;qXfer:libraries:read+;"
+                b"qXfer:exec-file:read+;qXfer:threads:read+;qXfer:memory-map:read+;"
+                b"QStartNoAckMode+;vContSupported+;swbreak+;hwbreak+"
+            )
+        elif payload == b"QStartNoAckMode":
+            self._reply(b"OK")
+            self._no_ack = True
+        elif payload == b"?":
+            self._reply(self._stop_reply(self._stop_reason))
+        elif payload == b"g":
+            self._read_registers()
+        elif payload.startswith(b"G"):
+            self._write_registers(payload[1:])
+        elif payload.startswith(b"p"):
+            self._read_register(payload[1:])
+        elif payload.startswith(b"P"):
+            self._write_register(payload[1:])
+        elif payload.startswith(b"m"):
+            self._read_memory(payload[1:])
+        elif payload.startswith(b"M"):
+            self._write_memory_hex(payload[1:])
+        elif payload.startswith(b"X"):
+            self._write_memory_binary(payload[1:])
+        elif payload[:1] in (b"Z", b"z"):
+            self._change_breakpoint(payload)
+        elif payload.startswith(b"qXfer:"):
+            response = self._handle_xfer(payload)
+            self._reply(response if response is not None else b"", binary=response is not None)
+        elif payload in (b"qAttached",) or payload.startswith(b"qAttached:"):
+            self._reply(b"1")
+        elif payload == b"qC":
+            self._reply(b"QC1")
+        elif payload == b"qfThreadInfo":
+            self._reply(b"m1")
+        elif payload == b"qsThreadInfo":
+            self._reply(b"l")
+        elif payload.startswith(b"qGetTIBAddr:"):
+            self._reply(f"{self._teb_address():x}".encode("ascii"))
+        elif payload.startswith(b"qSymbol"):
+            self._reply(b"OK")
+        elif payload.startswith(b"H"):
+            self._thread_command(payload)
+        elif payload.startswith(b"T"):
+            self._reply(b"OK" if payload[1:] in (b"1", b"0", b"-1") else b"E01")
+        elif payload == b"vCont?":
+            self._reply(b"vCont;c;s")
+        elif payload.startswith(b"vCont;"):
+            return self._resume_command(payload[6:])
+        elif payload[:1] in (b"c", b"s"):
+            if len(payload) > 1:
+                try:
+                    self.emu.set_pc(int(payload[1:], 16))
+                except ValueError:
+                    self._reply(b"E01")
+                    return None
+            return ResumeAction(step=payload[:1] == b"s")
+        elif payload.startswith(b"D"):
+            self._reply(b"OK")
+            return ResumeAction(detach=True)
+        elif payload[:1] in (b"k",) or payload.startswith(b"vKill"):
+            return ResumeAction(kill=True)
+        elif payload == b"!":
+            self._reply(b"")
+        else:
+            self._reply(b"")
+        return None
+
+    def _resume_command(self, actions: bytes) -> ResumeAction | None:
+        action_list = actions.split(b";")
+        step = any(item[:1] in (b"s", b"S") for item in action_list if item)
+        resume = step or any(item[:1] in (b"c", b"C") for item in action_list if item)
+        if not resume:
+            self._reply(b"E01")
+            return None
+        return ResumeAction(step=step)
+
+    def _thread_command(self, payload: bytes) -> None:
+        if len(payload) < 3 or payload[1:2] not in (b"g", b"c"):
+            self._reply(b"E01")
+            return
+        self._reply(b"OK" if payload[2:] in (b"0", b"1", b"-1") else b"E01")
+
+    def _change_breakpoint(self, payload: bytes) -> None:
+        try:
+            set_breakpoint = payload[:1] == b"Z"
+            bp_type_text, address_text, size_text = payload[1:].split(b",", 2)
+            bp_type = int(bp_type_text, 16)
+            address = int(address_text, 16)
+            size = int(size_text.split(b";", 1)[0], 16)
+            if size <= 0:
+                raise ValueError
+            key = (address, size)
+            if bp_type in (0, 1):
+                target = self._exec_breakpoints
+            elif bp_type == 2:
+                target = self._write_watchpoints
+            elif bp_type == 3:
+                target = self._read_watchpoints
+            elif bp_type == 4:
+                target = self._read_watchpoints
+                other = self._write_watchpoints
+                if set_breakpoint:
+                    other[key] = bp_type
+                else:
+                    other.pop(key, None)
+            else:
+                self._reply(b"")
+                return
+            if set_breakpoint:
+                target[key] = bp_type
+            else:
+                target.pop(key, None)
+            self._reply(b"OK")
+        except ValueError:
+            self._reply(b"E01")
+
+    # ------------------------------------------------------------------
+    # Registers and memory
+
+    def _make_registers(self) -> list[RegisterInfo]:
+        if self.emu.get_arch() == arch.ARCH_AMD64:
+            definitions = [
+                ("rax", ux.UC_X86_REG_RAX, 8),
+                ("rbx", ux.UC_X86_REG_RBX, 8),
+                ("rcx", ux.UC_X86_REG_RCX, 8),
+                ("rdx", ux.UC_X86_REG_RDX, 8),
+                ("rsi", ux.UC_X86_REG_RSI, 8),
+                ("rdi", ux.UC_X86_REG_RDI, 8),
+                ("rbp", ux.UC_X86_REG_RBP, 8),
+                ("rsp", ux.UC_X86_REG_RSP, 8),
+                *((f"r{i}", getattr(ux, f"UC_X86_REG_R{i}"), 8) for i in range(8, 16)),
+                ("rip", ux.UC_X86_REG_RIP, 8),
+                ("eflags", ux.UC_X86_REG_EFLAGS, 4),
+            ]
+        else:
+            definitions = [
+                ("eax", ux.UC_X86_REG_EAX, 4),
+                ("ecx", ux.UC_X86_REG_ECX, 4),
+                ("edx", ux.UC_X86_REG_EDX, 4),
+                ("ebx", ux.UC_X86_REG_EBX, 4),
+                ("esp", ux.UC_X86_REG_ESP, 4),
+                ("ebp", ux.UC_X86_REG_EBP, 4),
+                ("esi", ux.UC_X86_REG_ESI, 4),
+                ("edi", ux.UC_X86_REG_EDI, 4),
+                ("eip", ux.UC_X86_REG_EIP, 4),
+                ("eflags", ux.UC_X86_REG_EFLAGS, 4),
+            ]
+        definitions.extend(
+            (name, reg, 4)
+            for name, reg in (
+                ("cs", ux.UC_X86_REG_CS),
+                ("ss", ux.UC_X86_REG_SS),
+                ("ds", ux.UC_X86_REG_DS),
+                ("es", ux.UC_X86_REG_ES),
+                ("fs", ux.UC_X86_REG_FS),
+                ("gs", ux.UC_X86_REG_GS),
+            )
+        )
+        definitions.extend((f"st{i}", getattr(ux, f"UC_X86_REG_ST{i}"), 10, "float") for i in range(8))
+        # Unicorn does not expose all x87 environment fields independently.
+        # Keep their standard RSP slots so clients retain the canonical layout.
+        definitions.extend(
+            (name, None, 4, "float") for name in ("fctrl", "fstat", "ftag", "fiseg", "fioff", "foseg", "fooff", "fop")
+        )
+        xmm_count = 16 if self.emu.get_arch() == arch.ARCH_AMD64 else 8
+        definitions.extend((f"xmm{i}", getattr(ux, f"UC_X86_REG_XMM{i}"), 16, "vector") for i in range(xmm_count))
+        definitions.append(("mxcsr", ux.UC_X86_REG_MXCSR, 4, "vector"))
+        return [RegisterInfo(*definition) for definition in definitions]
+
+    @property
+    def _uc(self) -> Any:
+        return self.emu.emu_eng.emu
+
+    def _read_register_value(self, index: int) -> bytes:
+        register = self._registers[index]
+        if register.unicorn_id is None:
+            return bytes(register.size)
+        value = int(self._uc.reg_read(register.unicorn_id))
+        return value.to_bytes(register.size, "little")
+
+    def _read_registers(self) -> None:
+        try:
+            data = b"".join(self._read_register_value(index).hex().encode() for index in range(len(self._registers)))
+            self._reply(data)
+        except Exception:
+            self._reply(b"E01")
+
+    def _write_registers(self, encoded: bytes) -> None:
+        try:
+            data = bytes.fromhex(encoded.decode("ascii"))
+            offset = 0
+            for register in self._registers:
+                value = int.from_bytes(data[offset : offset + register.size], "little")
+                if len(data[offset : offset + register.size]) != register.size:
+                    raise ValueError
+                if register.unicorn_id is not None:
+                    self._uc.reg_write(register.unicorn_id, value)
+                offset += register.size
+            if offset != len(data):
+                raise ValueError
+            self._reply(b"OK")
+        except Exception:
+            self._reply(b"E01")
+
+    def _read_register(self, encoded_index: bytes) -> None:
+        try:
+            index = int(encoded_index, 16)
+            self._reply(self._read_register_value(index).hex().encode("ascii"))
+        except (ValueError, IndexError):
+            self._reply(b"E01")
+
+    def _write_register(self, payload: bytes) -> None:
+        try:
+            index_text, value_text = payload.split(b"=", 1)
+            index = int(index_text, 16)
+            register = self._registers[index]
+            value = bytes.fromhex(value_text.decode("ascii"))
+            if len(value) != register.size:
+                raise ValueError
+            if register.unicorn_id is not None:
+                self._uc.reg_write(register.unicorn_id, int.from_bytes(value, "little"))
+            self._reply(b"OK")
+        except (ValueError, IndexError, UnicodeDecodeError):
+            self._reply(b"E01")
+
+    def _read_memory(self, payload: bytes) -> None:
+        try:
+            address_text, size_text = payload.split(b",", 1)
+            address, size = int(address_text, 16), int(size_text, 16)
+            if address < 0 or size < 0 or size > _PACKET_SIZE // 2:
+                raise ValueError
+            self._reply(bytes(self.emu.mem_read(address, size)).hex().encode("ascii"))
+        except Exception:
+            self._reply(b"E01")
+
+    def _write_memory_hex(self, payload: bytes) -> None:
+        try:
+            info, encoded = payload.split(b":", 1)
+            address_text, size_text = info.split(b",", 1)
+            address, size = int(address_text, 16), int(size_text, 16)
+            data = bytes.fromhex(encoded.decode("ascii"))
+            if address < 0 or size < 0 or len(data) != size:
+                raise ValueError
+            self.emu.mem_write(address, data)
+            self._reply(b"OK")
+        except Exception:
+            self._reply(b"E01")
+
+    def _write_memory_binary(self, payload: bytes) -> None:
+        try:
+            info, data = payload.split(b":", 1)
+            address_text, size_text = info.split(b",", 1)
+            address, size = int(address_text, 16), int(size_text, 16)
+            if address < 0 or size < 0 or len(data) != size:
+                raise ValueError
+            self.emu.mem_write(address, data)
+            self._reply(b"OK")
+        except Exception:
+            self._reply(b"E01")
+
+    # ------------------------------------------------------------------
+    # XML and process metadata
+
+    def _handle_xfer(self, payload: bytes) -> bytes | None:
+        try:
+            object_name, operation, annex, position = payload[6:].split(b":", 3)
+            if operation != b"read":
+                return None
+            offset_text, length_text = position.split(b",", 1)
+            offset, requested = int(offset_text, 16), int(length_text, 16)
+            if offset < 0 or requested <= 0:
+                raise ValueError
+        except (ValueError, TypeError):
+            return b"E01"
+
+        if object_name == b"features" and annex == b"target.xml":
+            data = self._target_xml().encode()
+        elif object_name == b"libraries" and not annex:
+            data = self._library_xml().encode()
+        elif object_name == b"exec-file":
+            data = self._executable_path().encode()
+        elif object_name == b"threads" and not annex:
+            data = b'<threads><thread id="1" name="main"/></threads>'
+        elif object_name == b"memory-map" and not annex:
+            data = self._memory_map_xml().encode()
+        else:
+            return None
+
+        if offset >= len(data):
+            return b"l"
+        # Reserve one payload byte for the m/l marker. _reply will escape data.
+        chunk = data[offset : offset + min(requested, (_PACKET_SIZE - 1) // 2)]
+        marker = b"l" if offset + len(chunk) >= len(data) else b"m"
+        return marker + chunk
+
+    def _target_xml(self) -> str:
+        architecture = "i386:x86-64" if self.emu.get_arch() == arch.ARCH_AMD64 else "i386"
+        core_parts = []
+        for reg in self._registers:
+            if reg.group == "vector":
+                continue
+            attrs = f'name="{reg.name}" bitsize="{reg.size * 8}"'
+            if reg.name.startswith("st"):
+                attrs += ' type="i387_ext" group="float"'
+            elif reg.group:
+                attrs += f' group="{reg.group}"'
+            core_parts.append(f"<reg {attrs}/>")
+        core = "".join(core_parts)
+
+        vector_types = (
+            '<vector id="v4f" type="ieee_single" count="4"/>'
+            '<vector id="v2d" type="ieee_double" count="2"/>'
+            '<vector id="v16i8" type="int8" count="16"/>'
+            '<vector id="v8i16" type="int16" count="8"/>'
+            '<vector id="v4i32" type="int32" count="4"/>'
+            '<vector id="v2i64" type="int64" count="2"/>'
+            '<union id="vec128"><field name="v4_float" type="v4f"/>'
+            '<field name="v2_double" type="v2d"/><field name="v16_int8" type="v16i8"/>'
+            '<field name="v8_int16" type="v8i16"/><field name="v4_int32" type="v4i32"/>'
+            '<field name="v2_int64" type="v2i64"/><field name="uint128" type="uint128"/></union>'
+        )
+        vectors = "".join(
+            f'<reg name="{reg.name}" bitsize="{reg.size * 8}" '
+            f'type="{"vec128" if reg.name.startswith("xmm") else "int"}" group="vector"/>'
+            for reg in self._registers
+            if reg.group == "vector"
+        )
+        return (
+            '<?xml version="1.0"?><target>'
+            f"<architecture>{architecture}</architecture><osabi>Windows</osabi>"
+            f'<feature name="org.gnu.gdb.i386.core">{core}</feature>'
+            f'<feature name="org.gnu.gdb.i386.sse">{vector_types}{vectors}</feature></target>'
+        )
+
+    def _library_xml(self) -> str:
+        lines = ['<library-list version="1.0">']
+        for module in list(self.emu.modules):
+            path = str(getattr(module, "emu_path", "") or getattr(module, "path", ""))
+            base = getattr(module, "base", None)
+            if path and isinstance(base, int):
+                lines.append(
+                    f'<library name="{html.escape(path, quote=True)}">'
+                    f'<segment address="0x{base + 0x1000:x}"/></library>'
+                )
+        lines.append("</library-list>")
+        return "\n".join(lines)
+
+    def _memory_map_xml(self) -> str:
+        lines = ["<memory-map>"]
+        if self.emu.emu_eng is not None:
+            for begin, end, perms in self.emu.emu_eng.mem_regions():
+                # GDB's memory-map DTD has no permissions attribute. IDA maps
+                # RAM as RWX and ROM as RX, which is the closest representation.
+                memory_type = "ram" if perms & 2 else "rom"
+                lines.append(f'<memory type="{memory_type}" start="0x{begin:x}" length="0x{end - begin + 1:x}"/>')
+        lines.append("</memory-map>")
+        return "".join(lines)
+
+    def _executable_path(self) -> str:
+        run = getattr(self.emu, "curr_run", None)
+        start = getattr(run, "start_addr", None)
+        if isinstance(start, int):
+            module = self.emu.get_mod_from_addr(start)
+            if module is not None:
+                return str(getattr(module, "emu_path", ""))
+        modules = list(self.emu.modules)
+        return str(getattr(modules[0], "emu_path", "")) if modules else ""
+
+    def _teb_address(self) -> int:
+        thread = getattr(self.emu, "curr_thread", None)
+        teb = getattr(thread, "teb", None)
+        return int(getattr(teb, "address", 0) or 0)
+
+    @staticmethod
+    def _stop_reply(reason: StopReason) -> bytes:
+        reply = f"T{reason.signal:02x}thread:1;".encode("ascii")
+        if reason.kind in ("swbreak", "hwbreak"):
+            reply += reason.kind.encode("ascii") + b":;"
+        elif reason.kind in ("watch", "rwatch", "awatch") and reason.address is not None:
+            reply += f"{reason.kind}:{reason.address:x};".encode("ascii")
+        return reply

--- a/speakeasy/gdb.py
+++ b/speakeasy/gdb.py
@@ -77,7 +77,7 @@ class RegisterInfo:
 class GdbServer:
     """An all-stop RSP server backed directly by a WindowsEmulator."""
 
-    def __init__(self, emu: Any, port: int, host: str = "127.0.0.1"):
+    def __init__(self, emu: Any, port: int, host: str):
         self.emu = emu
         self.host = host
         self.port = port
@@ -97,8 +97,28 @@ class GdbServer:
         self._exec_breakpoints: dict[tuple[int, int], int] = {}
         self._read_watchpoints: dict[tuple[int, int], int] = {}
         self._write_watchpoints: dict[tuple[int, int], int] = {}
+        self._access_watchpoints: dict[tuple[int, int], int] = {}
         self._registers = self._make_registers()
         self._hooks: list[Any] = []
+        self._code_hook: Any | None = None
+        self._read_hook: Any | None = None
+        self._write_hook: Any | None = None
+
+    def __enter__(self) -> GdbServer:
+        try:
+            self.start()
+        except BaseException:
+            self.close()
+            raise
+        return self
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_value: BaseException | None,
+        traceback: Any,
+    ) -> None:
+        self.close()
 
     # ------------------------------------------------------------------
     # Transport
@@ -126,6 +146,13 @@ class GdbServer:
             except OSError:
                 pass
 
+    def notify_signal(self, signal: int) -> None:
+        if not self._closed.is_set():
+            try:
+                self._reply(f"X{signal & 0xFF:02x}".encode("ascii"))
+            except OSError:
+                pass
+
     def close(self) -> None:
         self._closed.set()
         for sock in (self._client, self._listener):
@@ -140,9 +167,14 @@ class GdbServer:
                     pass
         for hook in self._hooks:
             try:
-                hook.disable()
+                self._remove_hook(hook)
             except Exception:
                 pass
+        # Prevent BinaryEmulator.set_hooks() from restoring debugger hooks if
+        # emulation is started again after this session closes.
+        for registered_hooks in getattr(self.emu, "hooks", {}).values():
+            if isinstance(registered_hooks, list):
+                registered_hooks[:] = [hook for hook in registered_hooks if hook not in self._hooks]
 
     @staticmethod
     def _extract_packet(buffer: bytearray) -> tuple[bytes, bytes, bool] | None:
@@ -233,17 +265,25 @@ class GdbServer:
                 return ResumeAction(detach=True)
             action = self._handle_command(payload)
             if action is not None:
+                if not action.detach and not action.kill:
+                    # Mark the resume transition so Ctrl-C arriving before
+                    # begin_run() becomes a pending interrupt, not a queued '?'.
+                    with self._state_lock:
+                        self._running = True
                 return action
         return ResumeAction(detach=True)
 
-    def begin_run(self, action: ResumeAction) -> None:
+    def begin_run(self, action: ResumeAction) -> bool:
         with self._state_lock:
             self._running = True
-            self._stop_pending = False
+            if self._stop_pending:
+                return False
             self._stop_reason = StopReason()
             pc = self.emu.get_pc()
             at_breakpoint = any(begin <= pc < begin + size for begin, size in self._exec_breakpoints)
             self._resume_from_breakpoint = pc if at_breakpoint else None
+        self._refresh_hooks()
+        return True
 
     def finish_run(self, action: ResumeAction) -> StopReason | None:
         with self._state_lock:
@@ -272,13 +312,38 @@ class GdbServer:
             self._commands.put(b"?")
 
     def _install_hooks(self) -> None:
-        self._hooks.extend(
-            (
-                self.emu.add_code_hook(self._on_code),
-                self.emu.add_mem_read_hook(self._on_read),
-                self.emu.add_mem_write_hook(self._on_write),
-            )
+        self._code_hook = self.emu.add_code_hook(self._on_code)
+        self._read_hook = self.emu.add_mem_read_hook(self._on_read)
+        self._write_hook = self.emu.add_mem_write_hook(self._on_write)
+        self._hooks.extend((self._code_hook, self._read_hook, self._write_hook))
+        self._refresh_hooks()
+
+    @staticmethod
+    def _remove_hook(hook: Any) -> None:
+        if hook.added and hook.native_hook:
+            hook.emu_eng.hook_remove(hook.handle)
+        hook.handle = 0
+        hook.added = False
+        hook.enabled = False
+
+    @classmethod
+    def _set_hook_enabled(cls, hook: Any | None, enabled: bool) -> None:
+        if hook is None:
+            return
+        if enabled and not hook.added:
+            hook.add()
+        elif not enabled and hook.added:
+            # Hook.disable() still enters Python for every native event. Remove
+            # the Unicorn hook entirely to avoid that callback overhead.
+            cls._remove_hook(hook)
+
+    def _refresh_hooks(self) -> None:
+        self._set_hook_enabled(
+            self._code_hook,
+            bool(self._exec_breakpoints) or self._resume_from_breakpoint is not None,
         )
+        self._set_hook_enabled(self._read_hook, bool(self._read_watchpoints or self._access_watchpoints))
+        self._set_hook_enabled(self._write_hook, bool(self._write_watchpoints or self._access_watchpoints))
 
     def _on_code(self, _emu: Any, address: int, _size: int) -> bool:
         if self._resume_from_breakpoint == address:
@@ -292,12 +357,16 @@ class GdbServer:
         return True
 
     def _on_read(self, _emu: Any, _access: int, address: int, size: int, _value: int) -> bool:
-        if self._overlaps_watchpoint(self._read_watchpoints, address, size):
+        if self._overlaps_watchpoint(self._access_watchpoints, address, size):
+            self._request_stop(StopReason(kind="awatch", address=address))
+        elif self._overlaps_watchpoint(self._read_watchpoints, address, size):
             self._request_stop(StopReason(kind="rwatch", address=address))
         return True
 
     def _on_write(self, _emu: Any, _access: int, address: int, size: int, _value: int) -> bool:
-        if self._overlaps_watchpoint(self._write_watchpoints, address, size):
+        if self._overlaps_watchpoint(self._access_watchpoints, address, size):
+            self._request_stop(StopReason(kind="awatch", address=address))
+        elif self._overlaps_watchpoint(self._write_watchpoints, address, size):
             self._request_stop(StopReason(kind="watch", address=address))
         return True
 
@@ -411,12 +480,7 @@ class GdbServer:
             elif bp_type == 3:
                 target = self._read_watchpoints
             elif bp_type == 4:
-                target = self._read_watchpoints
-                other = self._write_watchpoints
-                if set_breakpoint:
-                    other[key] = bp_type
-                else:
-                    other.pop(key, None)
+                target = self._access_watchpoints
             else:
                 self._reply(b"")
                 return
@@ -424,6 +488,7 @@ class GdbServer:
                 target[key] = bp_type
             else:
                 target.pop(key, None)
+            self._refresh_hooks()
             self._reply(b"OK")
         except ValueError:
             self._reply(b"E01")
@@ -470,7 +535,7 @@ class GdbServer:
                 ("gs", ux.UC_X86_REG_GS),
             )
         )
-        definitions.extend((f"st{i}", getattr(ux, f"UC_X86_REG_ST{i}"), 10, "float") for i in range(8))
+        definitions.extend((f"st{i}", getattr(ux, f"UC_X86_REG_FP{i}"), 10, "float") for i in range(8))
         # Unicorn does not expose all x87 environment fields independently.
         # Keep their standard RSP slots so clients retain the canonical layout.
         definitions.extend(
@@ -489,8 +554,11 @@ class GdbServer:
         register = self._registers[index]
         if register.unicorn_id is None:
             return bytes(register.size)
-        value = int(self._uc.reg_read(register.unicorn_id))
-        return value.to_bytes(register.size, "little")
+        value = self._uc.reg_read(register.unicorn_id)
+        if register.name.startswith("st"):
+            mantissa, exponent = value
+            return int(mantissa).to_bytes(8, "little") + int(exponent).to_bytes(2, "little")
+        return int(value).to_bytes(register.size, "little")
 
     def _read_registers(self) -> None:
         try:
@@ -504,17 +572,26 @@ class GdbServer:
             data = bytes.fromhex(encoded.decode("ascii"))
             offset = 0
             for register in self._registers:
-                value = int.from_bytes(data[offset : offset + register.size], "little")
-                if len(data[offset : offset + register.size]) != register.size:
+                register_data = data[offset : offset + register.size]
+                if len(register_data) != register.size:
                     raise ValueError
-                if register.unicorn_id is not None:
-                    self._uc.reg_write(register.unicorn_id, value)
+                self._write_register_value(register, register_data)
                 offset += register.size
             if offset != len(data):
                 raise ValueError
             self._reply(b"OK")
         except Exception:
             self._reply(b"E01")
+
+    def _write_register_value(self, register: RegisterInfo, value: bytes) -> None:
+        if register.unicorn_id is None:
+            return
+        if register.name.startswith("st"):
+            mantissa = int.from_bytes(value[:8], "little")
+            exponent = int.from_bytes(value[8:], "little")
+            self._uc.reg_write(register.unicorn_id, (mantissa, exponent))
+        else:
+            self._uc.reg_write(register.unicorn_id, int.from_bytes(value, "little"))
 
     def _read_register(self, encoded_index: bytes) -> None:
         try:
@@ -531,8 +608,7 @@ class GdbServer:
             value = bytes.fromhex(value_text.decode("ascii"))
             if len(value) != register.size:
                 raise ValueError
-            if register.unicorn_id is not None:
-                self._uc.reg_write(register.unicorn_id, int.from_bytes(value, "little"))
+            self._write_register_value(register, value)
             self._reply(b"OK")
         except (ValueError, IndexError, UnicodeDecodeError):
             self._reply(b"E01")
@@ -576,8 +652,13 @@ class GdbServer:
     # XML and process metadata
 
     def _handle_xfer(self, payload: bytes) -> bytes | None:
+        # qXfer packets have the form:
+        # qXfer:<object>:<operation>:<annex>:<offset>,<length>
+        qxfer_prefix = b"qXfer:"
         try:
-            object_name, operation, annex, position = payload[6:].split(b":", 3)
+            if not payload.startswith(qxfer_prefix):
+                raise ValueError
+            object_name, operation, annex, position = payload.removeprefix(qxfer_prefix).split(b":", 3)
             if operation != b"read":
                 return None
             offset_text, length_text = position.split(b",", 1)

--- a/speakeasy/speakeasy.py
+++ b/speakeasy/speakeasy.py
@@ -37,7 +37,16 @@ class Speakeasy:
 
         return wrap
 
-    def __init__(self, config=None, argv=None, debug=False, exit_event=None, gdb_port=None, volumes=None):
+    def __init__(
+        self,
+        config=None,
+        argv=None,
+        debug=False,
+        exit_event=None,
+        gdb_port=None,
+        volumes=None,
+        gdb_host="127.0.0.1",
+    ):
 
         if volumes:
             if isinstance(config, SpeakeasyConfig):
@@ -59,6 +68,7 @@ class Speakeasy:
         self.exit_event = exit_event
         self.debug = debug
         self.gdb_port = gdb_port
+        self.gdb_host = gdb_host
         self.loaded_bins: list[str | None] = []
         self.mem_write_hooks: list[tuple[Callable, int, int]] = []
         self.mem_invalid_hooks: list[tuple[Callable]] = []
@@ -112,7 +122,11 @@ class Speakeasy:
 
             if pe.is_driver():
                 self.emu = WinKernelEmulator(
-                    config=self.config, debug=self.debug, exit_event=self.exit_event, gdb_port=self.gdb_port
+                    config=self.config,
+                    debug=self.debug,
+                    exit_event=self.exit_event,
+                    gdb_port=self.gdb_port,
+                    gdb_host=self.gdb_host,
                 )
             else:
                 self.emu = Win32Emulator(
@@ -121,6 +135,7 @@ class Speakeasy:
                     debug=self.debug,
                     exit_event=self.exit_event,
                     gdb_port=self.gdb_port,
+                    gdb_host=self.gdb_host,
                 )
         else:
             self.emu = Win32Emulator(
@@ -129,6 +144,7 @@ class Speakeasy:
                 debug=self.debug,
                 exit_event=self.exit_event,
                 gdb_port=self.gdb_port,
+                gdb_host=self.gdb_host,
             )
 
     def _init_hooks(self) -> None:

--- a/speakeasy/windows/kernel.py
+++ b/speakeasy/windows/kernel.py
@@ -27,7 +27,7 @@ class WinKernelEmulator(WindowsEmulator, IoManager):
     Class used to emulate Windows drivers
     """
 
-    def __init__(self, config, debug=False, exit_event=None, gdb_port=None, gdb_host="127.0.0.1"):
+    def __init__(self, config, debug=False, exit_event=None, gdb_port=None, gdb_host=None):
         super().__init__(config, debug=debug, exit_event=exit_event, gdb_port=gdb_port, gdb_host=gdb_host)
 
         self.disasm_eng: object | None = None

--- a/speakeasy/windows/kernel.py
+++ b/speakeasy/windows/kernel.py
@@ -27,8 +27,8 @@ class WinKernelEmulator(WindowsEmulator, IoManager):
     Class used to emulate Windows drivers
     """
 
-    def __init__(self, config, debug=False, exit_event=None, gdb_port=None):
-        super().__init__(config, debug=debug, exit_event=exit_event, gdb_port=gdb_port)
+    def __init__(self, config, debug=False, exit_event=None, gdb_port=None, gdb_host="127.0.0.1"):
+        super().__init__(config, debug=debug, exit_event=exit_event, gdb_port=gdb_port, gdb_host=gdb_host)
 
         self.disasm_eng: object | None = None
         self.curr_mod: object | None = None

--- a/speakeasy/windows/loaders.py
+++ b/speakeasy/windows/loaders.py
@@ -341,7 +341,7 @@ class PeLoader:
             default_export_mode="intercepted",
             entry_points=entry_points,
             visible_in_peb=True,
-            stack_size=pe.OPTIONAL_HEADER.SizeOfStackReserve or 0x12000,
+            stack_size=max(pe.OPTIONAL_HEADER.SizeOfStackReserve or 0, 0x12000),
             tls_callbacks=tls_callbacks,
             tls_directory_va=tls_directory_va,
             loader=self,

--- a/speakeasy/windows/win32.py
+++ b/speakeasy/windows/win32.py
@@ -31,8 +31,8 @@ class Win32Emulator(WindowsEmulator):
     User Mode Windows Emulator Class
     """
 
-    def __init__(self, config, argv=None, debug=False, exit_event=None, gdb_port=None):
-        super().__init__(config, debug=debug, exit_event=exit_event, gdb_port=gdb_port)
+    def __init__(self, config, argv=None, debug=False, exit_event=None, gdb_port=None, gdb_host="127.0.0.1"):
+        super().__init__(config, debug=debug, exit_event=exit_event, gdb_port=gdb_port, gdb_host=gdb_host)
 
         self.last_error = 0
         self.peb_addr = 0

--- a/speakeasy/windows/win32.py
+++ b/speakeasy/windows/win32.py
@@ -31,7 +31,7 @@ class Win32Emulator(WindowsEmulator):
     User Mode Windows Emulator Class
     """
 
-    def __init__(self, config, argv=None, debug=False, exit_event=None, gdb_port=None, gdb_host="127.0.0.1"):
+    def __init__(self, config, argv=None, debug=False, exit_event=None, gdb_port=None, gdb_host=None):
         super().__init__(config, debug=debug, exit_event=exit_event, gdb_port=gdb_port, gdb_host=gdb_host)
 
         self.last_error = 0

--- a/speakeasy/windows/winemu.py
+++ b/speakeasy/windows/winemu.py
@@ -81,11 +81,12 @@ class WindowsEmulator(BinaryEmulator):
         """Initialize configured processes. Subclasses must implement."""
         ...
 
-    def __init__(self, config, exit_event=None, debug=False, gdb_port=None):
+    def __init__(self, config, exit_event=None, debug=False, gdb_port=None, gdb_host="127.0.0.1"):
         super().__init__(config)
 
         self.debug: bool = debug
         self.gdb_port: int | None = gdb_port
+        self.gdb_host: str = gdb_host
         self.arch: int = 0
         self.modules: list[Any] = []
         self._setup_done: bool = False
@@ -568,17 +569,24 @@ class WindowsEmulator(BinaryEmulator):
         # so the first stop reports a meaningful PC/SP/etc.
         self._prepare_run_context(run)
 
+        debugger = None
+        debug_action = None
+        detached_resume_addr = None
         if self.gdb_port is not None:
-            from udbserver import udbserver
+            from speakeasy.gdb import GdbServer
 
-            logger.info(
-                "GDB server listening on port %d, waiting for connection (initial PC: 0x%x)...",
-                self.gdb_port,
-                self.curr_run.start_addr,  # type: ignore[union-attr]
-            )
-            udbserver(self.emu_eng.emu, port=self.gdb_port, start_addr=0)  # type: ignore[union-attr]
+            debugger = GdbServer(self, self.gdb_port, self.gdb_host)
+            debugger.start()
+            debug_action = debugger.command_loop()
+            if debug_action.kill:
+                debugger.close()
+                self.on_emu_complete()
+                return
+            if debug_action.detach:
+                debugger.close()
+                debugger = None
 
-        timeout = 0 if self.gdb_port is not None else self.config.timeout
+        timeout = 0 if debugger is not None else self.config.timeout
 
         if self.profiler:
             self.profiler.set_start_time()
@@ -586,7 +594,29 @@ class WindowsEmulator(BinaryEmulator):
         while True:
             try:
                 self.curr_mod = self.get_module_from_addr(self.curr_run.start_addr)  # type: ignore[union-attr]
-                self.emu_eng.start(self.curr_run.start_addr, timeout=timeout, count=self.config.max_instructions)  # type: ignore[union-attr]
+                if debugger is not None:
+                    resume_addr = self.get_pc()
+                else:
+                    resume_addr = detached_resume_addr or self.curr_run.start_addr  # type: ignore[union-attr]
+                    detached_resume_addr = None
+                instruction_count = 1 if debugger is not None and debug_action.step else self.config.max_instructions
+                if debugger is not None:
+                    debugger.begin_run(debug_action)
+                self.emu_eng.start(resume_addr, timeout=timeout, count=instruction_count)  # type: ignore[union-attr]
+                if debugger is not None:
+                    stop_reason = debugger.finish_run(debug_action)
+                    if stop_reason is not None:
+                        debug_action = debugger.command_loop(stop_reason)
+                        if debug_action.kill:
+                            debugger.close()
+                            self.on_emu_complete()
+                            return
+                        if debug_action.detach:
+                            detached_resume_addr = self.get_pc()
+                            debugger.close()
+                            debugger = None
+                            timeout = self.config.timeout
+                        continue
                 if self.profiler and timeout > 0:
                     if self.profiler.get_run_time() > timeout:
                         logger.error("* Timeout of %d sec(s) reached.", timeout)
@@ -615,6 +645,9 @@ class WindowsEmulator(BinaryEmulator):
                 continue
             break
 
+        if debugger is not None:
+            debugger.notify_exit(0)
+            debugger.close()
         self.on_emu_complete()
 
     def get_current_run(self):

--- a/speakeasy/windows/winemu.py
+++ b/speakeasy/windows/winemu.py
@@ -17,6 +17,7 @@ import speakeasy.winenv.defs.nt.ddk as ddk
 import speakeasy.winenv.defs.windows.windows as windef
 from speakeasy.binemu import BinaryEmulator
 from speakeasy.errors import WindowsEmuError
+from speakeasy.gdb import GdbServer, ResumeAction, StopReason
 from speakeasy.profiler import MemAccess, Run
 from speakeasy.profiler_events import TracePosition
 from speakeasy.report import ErrorInfo, RegionInfo
@@ -81,12 +82,12 @@ class WindowsEmulator(BinaryEmulator):
         """Initialize configured processes. Subclasses must implement."""
         ...
 
-    def __init__(self, config, exit_event=None, debug=False, gdb_port=None, gdb_host="127.0.0.1"):
+    def __init__(self, config, exit_event=None, debug=False, gdb_port=None, gdb_host=None):
         super().__init__(config)
 
         self.debug: bool = debug
         self.gdb_port: int | None = gdb_port
-        self.gdb_host: str = gdb_host
+        self.gdb_host: str | None = gdb_host
         self.arch: int = 0
         self.modules: list[Any] = []
         self._setup_done: bool = False
@@ -546,8 +547,10 @@ class WindowsEmulator(BinaryEmulator):
         self.mem_write(base, bytes(data))
 
     def resume(self, addr, count=-1):
-        """
-        Resume emulation at the specified address.
+        """Resume emulation directly at an address.
+
+        This low-level API bypasses the GDB command loop; callers that enable
+        GDB should drive execution through :meth:`start` instead.
         """
         timeout = 0 if self.gdb_port is not None else self.config.timeout
         self.emu_eng.start(addr, timeout=timeout, count=count)  # type: ignore[union-attr]
@@ -569,23 +572,35 @@ class WindowsEmulator(BinaryEmulator):
         # so the first stop reports a meaningful PC/SP/etc.
         self._prepare_run_context(run)
 
-        debugger = None
-        debug_action = None
-        detached_resume_addr = None
+        completed = True
         if self.gdb_port is not None:
-            from speakeasy.gdb import GdbServer
+            if self.gdb_host is None:
+                raise WindowsEmuError("A GDB bind host is required when gdb_port is set")
+            with GdbServer(self, self.gdb_port, self.gdb_host) as debugger:
+                debug_action = debugger.command_loop()
+                if debug_action.kill:
+                    completed = True
+                elif debug_action.detach:
+                    debugger.close()
+                    completed = self._execute_runs()
+                else:
+                    completed = self._execute_runs(debugger, debug_action)
+        else:
+            completed = self._execute_runs()
 
-            debugger = GdbServer(self, self.gdb_port, self.gdb_host)
-            debugger.start()
-            debug_action = debugger.command_loop()
-            if debug_action.kill:
-                debugger.close()
-                self.on_emu_complete()
-                return
-            if debug_action.detach:
-                debugger.close()
-                debugger = None
+        if completed:
+            self.on_emu_complete()
 
+    def _execute_runs(
+        self,
+        debugger: GdbServer | None = None,
+        debug_action: ResumeAction | None = None,
+    ) -> bool:
+        """Execute prepared runs, optionally under control of an active GDB session."""
+        if debugger is not None:
+            assert debug_action is not None
+        detached_resume_addr = None
+        terminal_signal = 0
         timeout = 0 if debugger is not None else self.config.timeout
 
         if self.profiler:
@@ -600,17 +615,15 @@ class WindowsEmulator(BinaryEmulator):
                     resume_addr = detached_resume_addr or self.curr_run.start_addr  # type: ignore[union-attr]
                     detached_resume_addr = None
                 instruction_count = 1 if debugger is not None and debug_action.step else self.config.max_instructions
-                if debugger is not None:
-                    debugger.begin_run(debug_action)
-                self.emu_eng.start(resume_addr, timeout=timeout, count=instruction_count)  # type: ignore[union-attr]
+                should_execute = debugger is None or debugger.begin_run(debug_action)
+                if should_execute:
+                    self.emu_eng.start(resume_addr, timeout=timeout, count=instruction_count)  # type: ignore[union-attr]
                 if debugger is not None:
                     stop_reason = debugger.finish_run(debug_action)
                     if stop_reason is not None:
                         debug_action = debugger.command_loop(stop_reason)
                         if debug_action.kill:
-                            debugger.close()
-                            self.on_emu_complete()
-                            return
+                            return True
                         if debug_action.detach:
                             detached_resume_addr = self.get_pc()
                             debugger.close()
@@ -622,10 +635,12 @@ class WindowsEmulator(BinaryEmulator):
                         logger.error("* Timeout of %d sec(s) reached.", timeout)
             except KeyboardInterrupt:
                 logger.error("* User exited.")
-                return
+                if debugger is not None:
+                    debugger.notify_signal(2)
+                return False
             except Exception as e:
                 if self.exit_event and self.exit_event.is_set():
-                    return
+                    return False
                 stack_trace = traceback.format_exc()
 
                 try:
@@ -635,6 +650,21 @@ class WindowsEmulator(BinaryEmulator):
 
                 error = self.get_error_info(str(e), self.get_pc(), traceback=stack_trace)
                 self.curr_run.error = error  # type: ignore[union-attr]
+                terminal_signal = 11
+
+                if debugger is not None:
+                    # Ensure a pending Ctrl-C cannot be lost, then report the
+                    # target fault while its register state is still available.
+                    debugger.finish_run(debug_action)
+                    debug_action = debugger.command_loop(
+                        StopReason(signal=terminal_signal, kind="exception", address=self.get_pc())
+                    )
+                    if debug_action.kill:
+                        return True
+                    if debug_action.detach:
+                        debugger.close()
+                        debugger = None
+                        timeout = self.config.timeout
 
                 run = self.on_run_complete()
                 if not run:
@@ -646,9 +676,11 @@ class WindowsEmulator(BinaryEmulator):
             break
 
         if debugger is not None:
-            debugger.notify_exit(0)
-            debugger.close()
-        self.on_emu_complete()
+            if terminal_signal:
+                debugger.notify_signal(terminal_signal)
+            else:
+                debugger.notify_exit(0)
+        return True
 
     def get_current_run(self):
         """

--- a/tests/test_gdb.py
+++ b/tests/test_gdb.py
@@ -5,10 +5,38 @@ import subprocess
 import sys
 import textwrap
 import time
+from dataclasses import dataclass
 
 import pytest
 
 TESTS_DIR = os.path.dirname(__file__)
+
+
+@dataclass(frozen=True)
+class X86Registers:
+    eax: int
+    ecx: int
+    edx: int
+    ebx: int
+    esp: int
+    ebp: int
+    esi: int
+    edi: int
+    eip: int
+    eflags: int
+    cs: int
+    ss: int
+    ds: int
+    es: int
+    fs: int
+    gs: int
+
+    @classmethod
+    def from_rsp(cls, encoded: str):
+        # The i386 core feature begins with these sixteen 32-bit registers in
+        # the same order as the dataclass fields above.
+        core_layout = struct.Struct("<16I")
+        return cls(*core_layout.unpack(bytes.fromhex(encoded)[: core_layout.size]))
 
 
 class GdbRspClient:
@@ -67,6 +95,9 @@ class GdbRspClient:
 
     def read_registers(self) -> str:
         return self.send("g")
+
+    def read_x86_registers(self) -> X86Registers:
+        return X86Registers.from_rsp(self.read_registers())
 
     def read_memory(self, addr: int, size: int) -> str:
         return self.send(f"m{addr:x},{size:x}")
@@ -133,6 +164,29 @@ _PAUSE_SERVER_SCRIPT = textwrap.dedent("""\
 
     se = Speakeasy(config=cfg, gdb_port=port)
     address = se.load_shellcode(data=b"\\xeb\\xfe", arch="x86")
+    se.run_shellcode(address)
+    se.shutdown()
+""")
+
+
+_FAULT_SERVER_SCRIPT = textwrap.dedent("""\
+    import json
+    import sys
+
+    from speakeasy import Speakeasy
+
+    port = int(sys.argv[1])
+    config_path = sys.argv[2]
+    with open(config_path) as f:
+        cfg = json.load(f)
+
+    se = Speakeasy(config=cfg, gdb_port=port)
+    address = se.load_shellcode(data=b"\\x90\\xc3", arch="x86")
+
+    def fail_start(*args, **kwargs):
+        raise RuntimeError("forced execution failure")
+
+    se.emu.emu_eng.start = fail_start
     se.run_shellcode(address)
     se.shutdown()
 """)
@@ -213,9 +267,7 @@ def gdb_emulator():
 
 @pytest.fixture
 def gdb_x64_emulator():
-    # Exercise the explicit non-loopback override while clients still connect
-    # through loopback in the isolated test process.
-    port, proc = _start_module_server("dll_test_x64.dll.xz", host="0.0.0.0")
+    port, proc = _start_module_server("dll_test_x64.dll.xz")
     yield port
     _stop_server(proc)
 
@@ -231,11 +283,7 @@ def test_gdb_connect_and_read_registers(gdb_emulator):
         assert len(regs) > 0
         assert all(char in "0123456789abcdefxx" for char in regs.lower())
 
-        # x86 GDB register order: eax(0), ecx(8), edx(16), ebx(24),
-        # esp(32), ebp(40), esi(48), edi(56), eip(64)
-        # Each register is 4 bytes = 8 hex chars.
-        eip_hex = regs[64:72].lower()
-        assert eip_hex not in ("00000000", "xxxxxxxx")
+        assert client.read_x86_registers().eip != 0
 
         client.continue_()
     finally:
@@ -248,11 +296,8 @@ def test_gdb_read_memory(gdb_emulator):
     try:
         client.query_halt_reason()
 
-        regs_hex = client.read_registers()
-        sp_hex = regs_hex[32:40]  # esp is at offset 32 (register #4)
-        sp = struct.unpack("<I", bytes.fromhex(sp_hex))[0]
-
-        mem = client.read_memory(sp, 4)
+        registers = client.read_x86_registers()
+        mem = client.read_memory(registers.esp, 4)
         assert len(mem) == 8
         assert all(char in "0123456789abcdef" for char in mem.lower())
 
@@ -306,6 +351,20 @@ def gdb_pause_emulator():
 
 
 @pytest.fixture
+def gdb_fault_emulator():
+    port = _find_free_port()
+    config_path = os.path.join(TESTS_DIR, "test.json")
+    proc = subprocess.Popen(
+        [sys.executable, "-c", _FAULT_SERVER_SCRIPT, str(port), config_path],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    _wait_for_port(port, proc)
+    yield port, proc
+    _stop_server(proc)
+
+
+@pytest.fixture
 def gdb_exit_emulator():
     port = _find_free_port()
     config_path = os.path.join(TESTS_DIR, "test.json")
@@ -326,8 +385,7 @@ def test_gdb_breakpoint_stop_keeps_session_alive(gdb_emulator):
     try:
         client.query_halt_reason()
         client.step()
-        registers = client.read_registers()
-        pc = struct.unpack("<I", bytes.fromhex(registers[64:72]))[0]
+        pc = client.read_x86_registers().eip
         code = bytes.fromhex(client.read_memory(pc, 16))
         instruction = next(iter(capstone.Cs(capstone.CS_ARCH_X86, capstone.CS_MODE_32).disasm(code, pc)))
         breakpoint = pc + instruction.size
@@ -337,11 +395,9 @@ def test_gdb_breakpoint_stop_keeps_session_alive(gdb_emulator):
         assert stop.startswith("T05")
         assert "swbreak:;" in stop
 
-        # The old udbserver backend closed its socket immediately after the
-        # stop reply. A register query proves the native session remains live.
-        stopped_registers = client.read_registers()
-        stopped_pc = struct.unpack("<I", bytes.fromhex(stopped_registers[64:72]))[0]
-        assert stopped_pc == breakpoint
+        # A register query after the stop reply verifies that the native
+        # debugger session remains live.
+        assert client.read_x86_registers().eip == breakpoint
 
         assert client.query(f"z0,{breakpoint:x},1") == "OK"
         assert client.continue_().startswith(("T", "W"))
@@ -385,6 +441,19 @@ def test_gdb_detach(gdb_pause_emulator):
         client.close()
 
 
+def test_gdb_reports_target_fault_and_nonzero_termination(gdb_fault_emulator):
+    port, proc = gdb_fault_emulator
+    client = GdbRspClient(port)
+    try:
+        client.query_halt_reason()
+        assert client.continue_().startswith("T0b")
+        assert client.read_x86_registers().eip != 0
+        assert client.continue_() == "X0b"
+        assert proc.wait(timeout=10) == 0
+    finally:
+        client.close()
+
+
 def test_gdb_reports_clean_exit(gdb_exit_emulator):
     port, proc = gdb_exit_emulator
     client = GdbRspClient(port)
@@ -402,14 +471,12 @@ def test_gdb_single_step(gdb_emulator):
     try:
         client.query_halt_reason()
 
-        registers = client.read_registers()
-        previous_eip = struct.unpack("<I", bytes.fromhex(registers[64:72]))[0]
+        previous_eip = client.read_x86_registers().eip
 
         for _ in range(3):
             response = client.step()
             assert response.startswith(("S", "T"))
-            registers = client.read_registers()
-            eip = struct.unpack("<I", bytes.fromhex(registers[64:72]))[0]
+            eip = client.read_x86_registers().eip
             assert eip != previous_eip
             previous_eip = eip
 

--- a/tests/test_gdb.py
+++ b/tests/test_gdb.py
@@ -8,11 +8,6 @@ import time
 
 import pytest
 
-if os.environ.get("SPEAKEASY_ENABLE_GDB_TESTS") != "1":
-    pytest.skip("Set SPEAKEASY_ENABLE_GDB_TESTS=1 to run GDB integration tests", allow_module_level=True)
-
-pytest.importorskip("udbserver")
-
 TESTS_DIR = os.path.dirname(__file__)
 
 
@@ -82,6 +77,17 @@ class GdbRspClient:
     def step(self) -> str:
         return self.send("s")
 
+    def query(self, packet: str) -> str:
+        return self.send(packet)
+
+    def send_no_wait(self, data: str):
+        packet = f"${data}#{self._checksum(data)}"
+        self.sock.sendall(packet.encode())
+
+    def interrupt(self) -> str:
+        self.sock.sendall(b"\x03")
+        return self._recv()
+
 
 def _find_free_port() -> int:
     with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
@@ -114,6 +120,42 @@ def _wait_for_port(port: int, proc: subprocess.Popen, timeout: float = 15.0):
     pytest.fail(f"GDB server did not start within {timeout}s: {stderr.decode(errors='replace')}")
 
 
+_PAUSE_SERVER_SCRIPT = textwrap.dedent("""\
+    import json
+    import sys
+
+    from speakeasy import Speakeasy
+
+    port = int(sys.argv[1])
+    config_path = sys.argv[2]
+    with open(config_path) as f:
+        cfg = json.load(f)
+
+    se = Speakeasy(config=cfg, gdb_port=port)
+    address = se.load_shellcode(data=b"\\xeb\\xfe", arch="x86")
+    se.run_shellcode(address)
+    se.shutdown()
+""")
+
+
+_EXIT_SERVER_SCRIPT = textwrap.dedent("""\
+    import json
+    import sys
+
+    from speakeasy import Speakeasy
+
+    port = int(sys.argv[1])
+    config_path = sys.argv[2]
+    with open(config_path) as f:
+        cfg = json.load(f)
+
+    se = Speakeasy(config=cfg, gdb_port=port)
+    address = se.load_shellcode(data=b"\\xc3", arch="x86")
+    se.run_shellcode(address)
+    se.shutdown()
+""")
+
+
 _SERVER_SCRIPT = textwrap.dedent("""\
     import json
     import lzma
@@ -124,46 +166,58 @@ _SERVER_SCRIPT = textwrap.dedent("""\
     port = int(sys.argv[1])
     config_path = sys.argv[2]
     bin_path = sys.argv[3]
+    host = sys.argv[4]
 
     with open(config_path) as f:
         cfg = json.load(f)
     with lzma.open(bin_path) as f:
         data = f.read()
 
-    se = Speakeasy(config=cfg, gdb_port=port)
+    se = Speakeasy(config=cfg, gdb_port=port, gdb_host=host)
     module = se.load_module(data=data)
     se.run_module(module, all_entrypoints=True)
     se.shutdown()
 """)
 
 
-@pytest.fixture
-def gdb_emulator():
-    """Start speakeasy with GDB enabled in a subprocess.
-
-    Uses a subprocess instead of a thread because udbserver's Rust FFI layer
-    can abort the process on error, which would kill the entire pytest session.
-    """
+def _start_module_server(filename: str, host: str = "127.0.0.1") -> tuple[int, subprocess.Popen]:
     port = _find_free_port()
     config_path = os.path.join(TESTS_DIR, "test.json")
-    bin_path = os.path.join(TESTS_DIR, "bins", "dll_test_x86.dll.xz")
-
+    bin_path = os.path.join(TESTS_DIR, "bins", filename)
     proc = subprocess.Popen(
-        [sys.executable, "-c", _SERVER_SCRIPT, str(port), config_path, bin_path],
+        [sys.executable, "-c", _SERVER_SCRIPT, str(port), config_path, bin_path, host],
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
     )
-
     _wait_for_port(port, proc)
+    return port, proc
 
-    yield port
 
-    proc.terminate()
+def _stop_server(proc: subprocess.Popen):
+    if proc.poll() is None:
+        proc.terminate()
     try:
         proc.wait(timeout=10)
     except subprocess.TimeoutExpired:
         proc.kill()
         proc.wait(timeout=5)
+
+
+@pytest.fixture
+def gdb_emulator():
+    """Start a 32-bit target with GDB enabled in an isolated subprocess."""
+    port, proc = _start_module_server("dll_test_x86.dll.xz")
+    yield port
+    _stop_server(proc)
+
+
+@pytest.fixture
+def gdb_x64_emulator():
+    # Exercise the explicit non-loopback override while clients still connect
+    # through loopback in the isolated test process.
+    port, proc = _start_module_server("dll_test_x64.dll.xz", host="0.0.0.0")
+    yield port
+    _stop_server(proc)
 
 
 def test_gdb_connect_and_read_registers(gdb_emulator):
@@ -207,21 +261,157 @@ def test_gdb_read_memory(gdb_emulator):
         client.close()
 
 
+def test_gdb_ida_process_metadata(gdb_emulator):
+    client = GdbRspClient(gdb_emulator)
+    try:
+        supported = client.query("qSupported:multiprocess+;xmlRegisters=i386")
+        assert "qXfer:libraries:read+" in supported
+        assert "qXfer:exec-file:read+" in supported
+        assert "qXfer:threads:read+" in supported
+
+        target = client.query("qXfer:features:read:target.xml:0,4000")
+        assert "<architecture>i386</architecture>" in target
+        assert 'name="eip" bitsize="32"' in target
+
+        libraries = client.query("qXfer:libraries:read::0,4000")
+        assert libraries.startswith("l<library-list")
+        assert "kernel32.dll" in libraries
+        assert '<segment address="0x' in libraries
+
+        executable = client.query("qXfer:exec-file:read::0,4000")
+        assert executable.startswith("lC:\\")
+        assert executable.endswith((".exe", ".dll", ".sys"))
+
+        threads = client.query("qXfer:threads:read::0,4000")
+        assert threads == 'l<threads><thread id="1" name="main"/></threads>'
+        assert client.query("qGetTIBAddr:1") != "0"
+
+        client.continue_()
+    finally:
+        client.close()
+
+
+@pytest.fixture
+def gdb_pause_emulator():
+    port = _find_free_port()
+    config_path = os.path.join(TESTS_DIR, "test.json")
+    proc = subprocess.Popen(
+        [sys.executable, "-c", _PAUSE_SERVER_SCRIPT, str(port), config_path],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    _wait_for_port(port, proc)
+    yield port
+    _stop_server(proc)
+
+
+@pytest.fixture
+def gdb_exit_emulator():
+    port = _find_free_port()
+    config_path = os.path.join(TESTS_DIR, "test.json")
+    proc = subprocess.Popen(
+        [sys.executable, "-c", _EXIT_SERVER_SCRIPT, str(port), config_path],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    _wait_for_port(port, proc)
+    yield port, proc
+    _stop_server(proc)
+
+
+def test_gdb_breakpoint_stop_keeps_session_alive(gdb_emulator):
+    import capstone
+
+    client = GdbRspClient(gdb_emulator)
+    try:
+        client.query_halt_reason()
+        client.step()
+        registers = client.read_registers()
+        pc = struct.unpack("<I", bytes.fromhex(registers[64:72]))[0]
+        code = bytes.fromhex(client.read_memory(pc, 16))
+        instruction = next(iter(capstone.Cs(capstone.CS_ARCH_X86, capstone.CS_MODE_32).disasm(code, pc)))
+        breakpoint = pc + instruction.size
+
+        assert client.query(f"Z0,{breakpoint:x},1") == "OK"
+        stop = client.continue_()
+        assert stop.startswith("T05")
+        assert "swbreak:;" in stop
+
+        # The old udbserver backend closed its socket immediately after the
+        # stop reply. A register query proves the native session remains live.
+        stopped_registers = client.read_registers()
+        stopped_pc = struct.unpack("<I", bytes.fromhex(stopped_registers[64:72]))[0]
+        assert stopped_pc == breakpoint
+
+        assert client.query(f"z0,{breakpoint:x},1") == "OK"
+        assert client.continue_().startswith(("T", "W"))
+    finally:
+        client.close()
+
+
+def test_gdb_ctrl_c_pauses_running_target(gdb_pause_emulator):
+    client = GdbRspClient(gdb_pause_emulator)
+    try:
+        client.query_halt_reason()
+        client.send_no_wait("c")
+        time.sleep(0.05)
+
+        stop = client.interrupt()
+        assert stop.startswith("T02")
+        assert client.read_registers()
+    finally:
+        client.close()
+
+
+def test_gdb_x64_target_description_and_registers(gdb_x64_emulator):
+    client = GdbRspClient(gdb_x64_emulator)
+    try:
+        target = client.query("qXfer:features:read:target.xml:0,4000")
+        assert target.startswith("l")
+        assert "<architecture>i386:x86-64</architecture>" in target
+        assert 'name="rip" bitsize="64"' in target
+        assert 'name="xmm15" bitsize="128"' in target
+        assert len(client.read_registers()) == 1072
+    finally:
+        client.close()
+
+
+def test_gdb_detach(gdb_pause_emulator):
+    client = GdbRspClient(gdb_pause_emulator)
+    try:
+        client.query_halt_reason()
+        assert client.query("D") == "OK"
+    finally:
+        client.close()
+
+
+def test_gdb_reports_clean_exit(gdb_exit_emulator):
+    port, proc = gdb_exit_emulator
+    client = GdbRspClient(port)
+    try:
+        client.query_halt_reason()
+        assert client.continue_() == "W00"
+        assert proc.wait(timeout=10) == 0
+    finally:
+        client.close()
+
+
 def test_gdb_single_step(gdb_emulator):
     port = gdb_emulator
     client = GdbRspClient(port)
     try:
         client.query_halt_reason()
 
-        regs_before = client.read_registers()
-        eip_before = struct.unpack("<I", bytes.fromhex(regs_before[64:72]))[0]
+        registers = client.read_registers()
+        previous_eip = struct.unpack("<I", bytes.fromhex(registers[64:72]))[0]
 
-        response = client.step()
-        assert response.startswith("S") or response.startswith("T")
-
-        regs_after = client.read_registers()
-        eip_after = struct.unpack("<I", bytes.fromhex(regs_after[64:72]))[0]
-        assert eip_after != eip_before
+        for _ in range(3):
+            response = client.step()
+            assert response.startswith(("S", "T"))
+            registers = client.read_registers()
+            eip = struct.unpack("<I", bytes.fromhex(registers[64:72]))[0]
+            assert eip != previous_eip
+            previous_eip = eip
 
         client.continue_()
     finally:

--- a/tests/test_gdb_compat.py
+++ b/tests/test_gdb_compat.py
@@ -1,7 +1,10 @@
 from dataclasses import dataclass
+from types import SimpleNamespace
 from xml.etree import ElementTree
 
-from speakeasy.gdb import GdbServer, _rsp_escape, _rsp_packet
+from unicorn import UC_ARCH_X86, UC_MODE_64, Uc
+
+from speakeasy.gdb import GdbServer, ResumeAction, _rsp_escape, _rsp_packet
 from speakeasy.winenv import arch
 
 
@@ -13,6 +16,20 @@ class DummyTeb:
 @dataclass
 class DummyThread:
     teb: DummyTeb
+
+
+class DummyHook:
+    def __init__(self):
+        self.enabled = True
+        self.added = True
+        self.native_hook = True
+        self.handle = 1
+        self.emu_eng = SimpleNamespace(hook_remove=lambda handle: None)
+
+    def add(self):
+        self.enabled = True
+        self.added = True
+        self.handle = 1
 
 
 class DummyModule:
@@ -32,12 +49,21 @@ class DummyEmulator:
     def get_arch(self):
         return arch.ARCH_AMD64
 
+    def add_code_hook(self, callback):
+        return DummyHook()
+
+    def add_mem_read_hook(self, callback):
+        return DummyHook()
+
+    def add_mem_write_hook(self, callback):
+        return DummyHook()
+
 
 def make_server():
-    return GdbServer(DummyEmulator(), 0)
+    return GdbServer(DummyEmulator(), 0, "127.0.0.1")
 
 
-def test_server_bind_host_defaults_to_loopback_and_can_be_overridden():
+def test_server_uses_provided_bind_host():
     assert make_server().host == "127.0.0.1"
     assert GdbServer(DummyEmulator(), 0, "0.0.0.0").host == "0.0.0.0"
 
@@ -110,6 +136,80 @@ def test_packet_extraction_validates_checksum_across_fragmented_input():
     oversized_payload = b"q" * (0x4000 + 1)
     oversized = _rsp_packet(oversized_payload)
     assert GdbServer._extract_packet(bytearray(oversized))[2] is False
+
+
+def test_interrupt_during_resume_transition_is_preserved():
+    server = make_server()
+    server.emu.emu_eng = SimpleNamespace(stop=lambda: None)
+    server._running = True
+
+    server._interrupt()
+
+    assert not server.begin_run(ResumeAction())
+    reason = server.finish_run(ResumeAction())
+    assert reason is not None
+    assert reason.signal == 2
+
+
+def test_instruction_and_memory_hooks_are_enabled_only_when_needed():
+    server = make_server()
+    server._reply = lambda payload: None
+    server._install_hooks()
+
+    assert not server._code_hook.enabled
+    assert not server._read_hook.enabled
+    assert not server._write_hook.enabled
+
+    server._change_breakpoint(b"Z0,1000,1")
+    assert server._code_hook.enabled
+    server._change_breakpoint(b"z0,1000,1")
+    assert not server._code_hook.enabled
+
+    server._change_breakpoint(b"Z4,2000,4")
+    assert server._read_hook.enabled
+    assert server._write_hook.enabled
+    server._change_breakpoint(b"z4,2000,4")
+    assert not server._read_hook.enabled
+    assert not server._write_hook.enabled
+
+
+def test_access_watchpoint_does_not_clobber_write_watchpoint():
+    server = make_server()
+    replies = []
+    server._reply = replies.append
+
+    server._change_breakpoint(b"Z4,1000,4")
+    server._change_breakpoint(b"Z2,1000,4")
+    server._change_breakpoint(b"z4,1000,4")
+
+    assert (0x1000, 4) not in server._access_watchpoints
+    assert (0x1000, 4) in server._write_watchpoints
+    assert replies == [b"OK", b"OK", b"OK"]
+
+
+def test_access_watchpoint_reports_awatch_stop_reason():
+    server = make_server()
+    reasons = []
+    server._access_watchpoints[(0x1000, 4)] = 4
+    server._request_stop = reasons.append
+
+    server._on_read(None, 0, 0x1001, 1, 0)
+
+    assert len(reasons) == 1
+    assert reasons[0].kind == "awatch"
+    assert b"awatch:1001;" in server._stop_reply(reasons[0])
+
+
+def test_x87_registers_use_full_80_bit_wire_format():
+    emulator = DummyEmulator()
+    emulator.emu_eng = SimpleNamespace(emu=Uc(UC_ARCH_X86, UC_MODE_64))
+    server = GdbServer(emulator, 0, "127.0.0.1")
+    st0_index = next(index for index, register in enumerate(server._registers) if register.name == "st0")
+    wire_value = (3).to_bytes(8, "little") + (0x7FFF).to_bytes(2, "little")
+
+    server._write_register_value(server._registers[st0_index], wire_value)
+
+    assert server._read_register_value(st0_index) == wire_value
 
 
 def test_xfer_escaping_respects_advertised_packet_size():

--- a/tests/test_gdb_compat.py
+++ b/tests/test_gdb_compat.py
@@ -1,0 +1,124 @@
+from dataclasses import dataclass
+from xml.etree import ElementTree
+
+from speakeasy.gdb import GdbServer, _rsp_escape, _rsp_packet
+from speakeasy.winenv import arch
+
+
+@dataclass
+class DummyTeb:
+    address: int
+
+
+@dataclass
+class DummyThread:
+    teb: DummyTeb
+
+
+class DummyModule:
+    def __init__(self, path, base):
+        self.emu_path = path
+        self.base = base
+
+
+class DummyEmulator:
+    def __init__(self):
+        self.modules = [
+            DummyModule(r"C:\sample.exe", 0x400000),
+            DummyModule(r"C:\Windows\System32\weird&name.dll", 0x70000000),
+        ]
+        self.curr_thread = DummyThread(DummyTeb(0x7FFDE000))
+
+    def get_arch(self):
+        return arch.ARCH_AMD64
+
+
+def make_server():
+    return GdbServer(DummyEmulator(), 0)
+
+
+def test_server_bind_host_defaults_to_loopback_and_can_be_overridden():
+    assert make_server().host == "127.0.0.1"
+    assert GdbServer(DummyEmulator(), 0, "0.0.0.0").host == "0.0.0.0"
+
+
+def test_supported_features_include_ida_process_queries():
+    server = make_server()
+    replies = []
+    server._reply = replies.append
+
+    server._handle_command(b"qSupported:multiprocess+;xmlRegisters=i386")
+
+    response = replies[0]
+    assert b"qXfer:features:read+" in response
+    assert b"qXfer:libraries:read+" in response
+    assert b"qXfer:exec-file:read+" in response
+    assert b"qXfer:threads:read+" in response
+    assert b"qXfer:memory-map:read+" in response
+
+
+def test_target_description_matches_native_x64_register_layout():
+    response = make_server()._handle_xfer(b"qXfer:features:read:target.xml:0,4000")
+    root = ElementTree.fromstring(response[1:])
+    registers = root.findall(".//reg")
+
+    assert response.startswith(b"l<?xml")
+    assert root.findtext("architecture") == "i386:x86-64"
+    assert root.findtext("osabi") == "Windows"
+    assert len(registers) == 57
+    assert sum(int(register.attrib["bitsize"]) for register in registers) == 4288
+    assert any(register.attrib["name"] == "rip" for register in registers)
+
+
+def test_library_list_uses_windows_gdb_segment_convention():
+    response = make_server()._handle_xfer(b"qXfer:libraries:read::0,4000")
+
+    assert response.startswith(b"l<library-list")
+    assert b'name="C:\\sample.exe"' in response
+    assert b'address="0x401000"' in response
+    assert b"weird&amp;name.dll" in response
+    assert b'address="0x70001000"' in response
+
+
+def test_xfer_chunking_and_process_metadata():
+    server = make_server()
+
+    first = server._handle_xfer(b"qXfer:exec-file:read::0,4")
+    second = server._handle_xfer(b"qXfer:exec-file:read::4,100")
+
+    assert first == b"mC:\\s"
+    assert second == b"lample.exe"
+    assert server._handle_xfer(b"qXfer:exec-file:read:2a:0,100") == b"lC:\\sample.exe"
+    assert server._teb_address() == 0x7FFDE000
+
+
+def test_packet_extraction_validates_checksum_across_fragmented_input():
+    raw = _rsp_packet(b"qC")
+    buffer = bytearray(raw[:-1])
+    assert GdbServer._extract_packet(buffer) is None
+
+    buffer.extend(raw[-1:])
+    assert GdbServer._extract_packet(buffer) == (raw, b"qC", True)
+
+    corrupt = bytearray(raw)
+    corrupt[-1] = ord("0") if corrupt[-1] != ord("0") else ord("1")
+    assert GdbServer._extract_packet(corrupt)[2] is False
+
+    trailing_escape = _rsp_packet(b"qC}")
+    assert GdbServer._extract_packet(bytearray(trailing_escape))[2] is False
+
+    oversized_payload = b"q" * (0x4000 + 1)
+    oversized = _rsp_packet(oversized_payload)
+    assert GdbServer._extract_packet(bytearray(oversized))[2] is False
+
+
+def test_xfer_escaping_respects_advertised_packet_size():
+    server = make_server()
+    server._executable_path = lambda: "$#}*" * 5000
+
+    response = server._handle_xfer(b"qXfer:exec-file:read::0,ffff")
+    encoded = response[:1] + _rsp_escape(response[1:])
+
+    assert response.startswith(b"m")
+    assert len(encoded) <= 0x4000
+    assert all(value not in encoded[1:] for value in b"$#*")


### PR DESCRIPTION
The upstream udbserver dependency was not working correctly (missing packets, no proper stop reasons etc), so I had the clanker (gpt-5.6-sol) rewrite it completely in Python.

The loader change also preserves Speakeasy's existing `0x12000` minimum modeled stack reserve when a PE declares a smaller value, avoiding under-allocation of the emulator's stack layout.

<img width="1726" height="1022" alt="image" src="https://github.com/user-attachments/assets/1ef04209-cdf5-4836-89f6-17ccc03f253b" />
