### PR TITLE
binemu: map stack as RW instead of RWX

### DIFF
--- a/speakeasy/binemu.py
+++ b/speakeasy/binemu.py
@@ -600,7 +600,7 @@ class BinaryEmulator(MemoryManager, ABC):
         # Stack grows down
         chunk = self.get_valid_ranges(size, addr=0x1200000)
         addr, block_size = chunk
-        self.mem_map(block_size, base=addr, tag="emu.stack")
+        self.mem_map(block_size, base=addr, tag="emu.stack", perms=common.PERM_MEM_RW)
 
         base = addr + block_size
         self.mem_reserve(size, base=base)


### PR DESCRIPTION
## Summary
- The emulated stack was mapped with RWX permissions (the `mem_map` default), but Windows stacks are RW by default — the execute bit should not be set.
- Changed `alloc_stack` to explicitly pass `perms=common.PERM_MEM_RW`.

Closes #296

## Test plan
- [x] All existing tests pass (`just test-all`: 753 passed)
- Malware samples that rely on stack execution (e.g., stack-based shellcode decoders) would now need to call `VirtualProtect` to make the stack executable, matching real Windows behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)