### PR TITLE
Fix set_func_args for x86 fastcall and x64 overflow args

### DIFF
--- a/speakeasy/binemu.py
+++ b/speakeasy/binemu.py
@@ -284,19 +284,27 @@ class BinaryEmulator(MemoryManager, ABC):
         """
         return self.disasm(self.mem_read(addr, size), addr, fast)
 
-    def set_func_args(self, stack_addr, ret_addr, *args, home_space=True):
+    def set_func_args(self, stack_addr, ret_addr, *args, home_space=True, conv=None):
         """
         Set the arguments before an emulated function call. This is how we pass
         arguments to a function when calling it through the emulator.
         """
-        curr_sp = stack_addr - self.ptr_size
         nargs = len(args)
+        curr_sp = stack_addr
 
         if self.get_arch() == e_arch.ARCH_X86:
-            sp = e_arch.X86_REG_ESP
+            sp_reg = e_arch.X86_REG_ESP
+
+            if conv == e_arch.CALL_CONV_FASTCALL:
+                for r in (e_arch.X86_REG_ECX, e_arch.X86_REG_EDX):
+                    if nargs == 0:
+                        break
+                    self.reg_write(r, args[len(args) - nargs])
+                    nargs -= 1
+
         elif self.get_arch() == e_arch.ARCH_AMD64:
-            sp = e_arch.AMD64_REG_RSP
-            i = 0
+            sp_reg = e_arch.AMD64_REG_RSP
+
             for i, r in enumerate(
                 (e_arch.AMD64_REG_RCX, e_arch.AMD64_REG_RDX, e_arch.AMD64_REG_R8, e_arch.AMD64_REG_R9)
             ):
@@ -304,25 +312,20 @@ class BinaryEmulator(MemoryManager, ABC):
                     break
                 self.reg_write(r, args[i])
                 nargs -= 1
-            # Set the stack home space
-            if home_space:
-                curr_sp -= 0x20
-            self.reg_write(sp, curr_sp)
         else:
             raise EmuException("Unsupported architecture")
 
         if nargs > 0:
             for arg in args[-nargs:][::-1]:
-                a = arg.to_bytes(self.ptr_size, byteorder="little")
-
-                self.mem_write(curr_sp, a)
-                self.reg_write(sp, curr_sp)
                 curr_sp -= self.ptr_size
+                self.mem_write(curr_sp, arg.to_bytes(self.ptr_size, byteorder="little"))
 
-        # Set the return address
-        r = ret_addr.to_bytes(self.ptr_size, byteorder="little")
-        self.mem_write(curr_sp, r)
-        self.reg_write(sp, curr_sp)
+        if self.get_arch() == e_arch.ARCH_AMD64 and home_space:
+            curr_sp -= 0x20
+
+        curr_sp -= self.ptr_size
+        self.mem_write(curr_sp, ret_addr.to_bytes(self.ptr_size, byteorder="little"))
+        self.reg_write(sp_reg, curr_sp)
 
     def get_func_argv(self, callconv, argc):
         """

--- a/speakeasy/binemu.py
+++ b/speakeasy/binemu.py
@@ -600,7 +600,7 @@ class BinaryEmulator(MemoryManager, ABC):
         # Stack grows down
         chunk = self.get_valid_ranges(size, addr=0x1200000)
         addr, block_size = chunk
-        self.mem_map(block_size, base=addr, tag="emu.stack")
+        self.mem_map(block_size, base=addr, tag="emu.stack", perms=common.PERM_MEM_RW)
 
         base = addr + block_size
         self.mem_reserve(size, base=base)

--- a/speakeasy/binemu.py
+++ b/speakeasy/binemu.py
@@ -284,10 +284,25 @@ class BinaryEmulator(MemoryManager, ABC):
         """
         return self.disasm(self.mem_read(addr, size), addr, fast)
 
-    def set_func_args(self, stack_addr, ret_addr, *args, home_space=True, conv=None):
+    def set_func_args(self, stack_addr, ret_addr, *args, conv, home_space=True):
         """
-        Set the arguments before an emulated function call. This is how we pass
-        arguments to a function when calling it through the emulator.
+        Set the arguments before an emulated function call.
+
+        Lays out *args* according to *conv* and the current architecture,
+        writes *ret_addr* at the top of the resulting stack frame, and
+        updates the stack-pointer register.
+
+        On x86 fastcall the first two arguments go into ECX/EDX; on x64
+        the first four go into RCX/RDX/R8/R9.  Remaining arguments are
+        pushed onto the stack.  On x64 a 32-byte shadow (home) space is
+        reserved above the return address when *home_space* is True.
+
+        Args:
+            stack_addr: Base address of the stack region.
+            ret_addr: Return address to place on the stack.
+            *args: Argument values to pass to the callee.
+            conv: Calling convention (e.g. ``CALL_CONV_STDCALL``).
+            home_space: Reserve 32-byte x64 shadow space (default True).
         """
         nargs = len(args)
         curr_sp = stack_addr

--- a/speakeasy/windows/kernel.py
+++ b/speakeasy/windows/kernel.py
@@ -375,7 +375,7 @@ class WinKernelEmulator(WindowsEmulator, IoManager):
         Call a WDM driver dispatch function with a supplied IRP
         """
         stk_ptr = self.get_stack_ptr()
-        self.set_func_args(stk_ptr, self.return_hook, dev_addr, irp_addr)
+        self.set_func_args(stk_ptr, self.return_hook, dev_addr, irp_addr, conv=_arch.CALL_CONV_STDCALL)
         self.set_pc(func)
 
     def new_irp(self):
@@ -438,7 +438,7 @@ class WinKernelEmulator(WindowsEmulator, IoManager):
             return
 
         stk_ptr = self.get_stack_ptr()
-        self.set_func_args(stk_ptr, self.exit_hook, drv.address)
+        self.set_func_args(stk_ptr, self.exit_hook, drv.address, conv=_arch.CALL_CONV_STDCALL)
         self.set_pc(drv.on_unload)
 
         run = Run()

--- a/speakeasy/windows/win32.py
+++ b/speakeasy/windows/win32.py
@@ -178,7 +178,7 @@ class Win32Emulator(WindowsEmulator):
         image.emu_path = emu_path
 
         rtmod = self.load_image(image)
-        self.set_func_args(self.stack_base, self.return_hook)
+        self.set_func_args(self.stack_base, self.return_hook, conv=_arch.CALL_CONV_STDCALL)
 
         if self.input is not None:
             self.input["image_base"] = rtmod.base
@@ -431,7 +431,7 @@ class Win32Emulator(WindowsEmulator):
 
         effective_stack = self.config.stack_size or stack_commit
         self.stack_base, stack_addr = self.alloc_stack(effective_stack)
-        self.set_func_args(self.stack_base, self.return_hook, 0x7000)
+        self.set_func_args(self.stack_base, self.return_hook, 0x7000, conv=_arch.CALL_CONV_STDCALL)
 
         run = Run()
         run.type = "shellcode"

--- a/speakeasy/windows/winemu.py
+++ b/speakeasy/windows/winemu.py
@@ -446,7 +446,7 @@ class WindowsEmulator(BinaryEmulator):
 
         stk_ptr = self.get_stack_ptr()
 
-        self.set_func_args(stk_ptr, self.return_hook, *run.args)
+        self.set_func_args(stk_ptr, self.return_hook, *run.args, conv=_arch.CALL_CONV_STDCALL)
         stk_ptr = self.get_stack_ptr()
         stk_map = self.get_address_map(stk_ptr)
 
@@ -2558,7 +2558,7 @@ class WindowsEmulator(BinaryEmulator):
             self.mem_write(exception_list - ptr_size, p_exp_ptrs_bytes)
 
             args = [prec, exception_list, pctx, 0]
-            self.set_func_args(sp, winemu.SEH_RETURN_ADDR, *args)
+            self.set_func_args(sp, winemu.SEH_RETURN_ADDR, *args, conv=_arch.CALL_CONV_STDCALL)
 
             run = self.get_current_run()
             regs = self.get_register_state()
@@ -2647,7 +2647,7 @@ class WindowsEmulator(BinaryEmulator):
                 seh.frame = frame
                 scope_record = frame.scope_records[0]
                 if not scope_record.filter_called and scope_record.record.FilterFunc:
-                    self.set_func_args(sp, winemu.SEH_RETURN_ADDR)
+                    self.set_func_args(sp, winemu.SEH_RETURN_ADDR, conv=_arch.CALL_CONV_STDCALL)
                     self.set_pc(scope_record.record.FilterFunc)
                     seh.last_func = scope_record.record.FilterFunc
                     scope_record.filter_called = True
@@ -2729,7 +2729,7 @@ class WindowsEmulator(BinaryEmulator):
 
             sp = self.get_stack_ptr()
             args = [p_exp_ptrs]
-            self.set_func_args(sp, winemu.EMU_RETURN_ADDR, *args)
+            self.set_func_args(sp, winemu.EMU_RETURN_ADDR, *args, conv=_arch.CALL_CONV_STDCALL)
             self.set_pc(self.unhandled_exception_filter)
             self.unhandled_exception_filter = 0
             rv = True

--- a/speakeasy/winenv/api/api.py
+++ b/speakeasy/winenv/api/api.py
@@ -404,7 +404,7 @@ class ApiHandler:
             ret = self.emu.get_ret_address()
             sp = self.emu.get_stack_ptr()
 
-            self.emu.set_func_args(sp, winemu.API_CALLBACK_HANDLER_ADDR, *args)
+            self.emu.set_func_args(sp, winemu.API_CALLBACK_HANDLER_ADDR, *args, conv=_arch.CALL_CONV_STDCALL)
             self.emu.set_pc(func)
             run.api_callbacks.append((ret, func, caller_argv))
         else:

--- a/tests/test_func_args.py
+++ b/tests/test_func_args.py
@@ -46,59 +46,51 @@ def _make_args(argc):
     return [0x1000 + i for i in range(argc)]
 
 
-@pytest.fixture(autouse=True)
-def _reset_stack(emu):
-    yield
-    emu.reset_stack(emu.stack_base)
-
-
-class TestSetGetFuncArgs:
-    @pytest.mark.parametrize("argc", ARG_COUNTS)
-    def test_round_trip(self, emu, argc):
-        for conv in _convs_for_arch(emu.arch):
-            args = _make_args(argc)
-            emu.set_func_args(emu.stack_base, RET_ADDR, *args, conv=conv)
-            got = emu.get_func_argv(conv, argc)
-            assert got == args, (
-                f"arch={emu.arch}, conv={_conv_name(conv)}, argc={argc}: "
-                f"expected {[hex(a) for a in args]}, got {[hex(a) for a in got]}"
-            )
-            emu.reset_stack(emu.stack_base)
-
-    @pytest.mark.parametrize("argc", ARG_COUNTS)
-    def test_ret_address(self, emu, argc):
-        for conv in _convs_for_arch(emu.arch):
-            args = _make_args(argc)
-            emu.set_func_args(emu.stack_base, RET_ADDR, *args, conv=conv)
-            got_ret = emu.get_ret_address()
-            assert got_ret == RET_ADDR, (
-                f"arch={emu.arch}, conv={_conv_name(conv)}: "
-                f"ret expected {hex(RET_ADDR)}, got {hex(got_ret)}"
-            )
-            emu.reset_stack(emu.stack_base)
-
-
-class TestDoCallReturn:
-    @pytest.mark.parametrize("argc", ARG_COUNTS)
-    def test_x86_stdcall_stack_restored(self, emu, argc):
-        if emu.arch != e_arch.ARCH_X86:
-            pytest.skip("x86 only")
-        conv = e_arch.CALL_CONV_STDCALL
+@pytest.mark.parametrize("argc", ARG_COUNTS)
+def test_round_trip(emu, argc):
+    for conv in _convs_for_arch(emu.arch):
         args = _make_args(argc)
-        sp_before = emu.get_stack_ptr()
         emu.set_func_args(emu.stack_base, RET_ADDR, *args, conv=conv)
-        emu.do_call_return(argc, ret_addr=RET_ADDR, conv=conv)
-        sp_after = emu.get_stack_ptr()
-        assert sp_after == sp_before
+        got = emu.get_func_argv(conv, argc)
+        assert got == args, (
+            f"arch={emu.arch}, conv={_conv_name(conv)}, argc={argc}: "
+            f"expected {[hex(a) for a in args]}, got {[hex(a) for a in got]}"
+        )
+        emu.reset_stack(emu.stack_base)
 
-    @pytest.mark.parametrize("argc", ARG_COUNTS)
-    def test_x86_fastcall_stack_restored(self, emu, argc):
-        if emu.arch != e_arch.ARCH_X86:
-            pytest.skip("x86 only")
-        conv = e_arch.CALL_CONV_FASTCALL
+
+@pytest.mark.parametrize("argc", ARG_COUNTS)
+def test_ret_address(emu, argc):
+    for conv in _convs_for_arch(emu.arch):
         args = _make_args(argc)
-        sp_before = emu.get_stack_ptr()
         emu.set_func_args(emu.stack_base, RET_ADDR, *args, conv=conv)
-        emu.do_call_return(argc, ret_addr=RET_ADDR, conv=conv)
-        sp_after = emu.get_stack_ptr()
-        assert sp_after == sp_before
+        got_ret = emu.get_ret_address()
+        assert got_ret == RET_ADDR, (
+            f"arch={emu.arch}, conv={_conv_name(conv)}: "
+            f"ret expected {hex(RET_ADDR)}, got {hex(got_ret)}"
+        )
+        emu.reset_stack(emu.stack_base)
+
+
+@pytest.mark.parametrize("argc", ARG_COUNTS)
+def test_x86_stdcall_stack_restored(emu, argc):
+    if emu.arch != e_arch.ARCH_X86:
+        pytest.skip("x86 only")
+    conv = e_arch.CALL_CONV_STDCALL
+    args = _make_args(argc)
+    sp_before = emu.get_stack_ptr()
+    emu.set_func_args(emu.stack_base, RET_ADDR, *args, conv=conv)
+    emu.do_call_return(argc, ret_addr=RET_ADDR, conv=conv)
+    assert emu.get_stack_ptr() == sp_before
+
+
+@pytest.mark.parametrize("argc", ARG_COUNTS)
+def test_x86_fastcall_stack_restored(emu, argc):
+    if emu.arch != e_arch.ARCH_X86:
+        pytest.skip("x86 only")
+    conv = e_arch.CALL_CONV_FASTCALL
+    args = _make_args(argc)
+    sp_before = emu.get_stack_ptr()
+    emu.set_func_args(emu.stack_base, RET_ADDR, *args, conv=conv)
+    emu.do_call_return(argc, ret_addr=RET_ADDR, conv=conv)
+    assert emu.get_stack_ptr() == sp_before

--- a/tests/test_func_args.py
+++ b/tests/test_func_args.py
@@ -65,8 +65,7 @@ def test_ret_address(emu, argc):
         emu.set_func_args(emu.stack_base, RET_ADDR, *args, conv=conv)
         got_ret = emu.get_ret_address()
         assert got_ret == RET_ADDR, (
-            f"arch={emu.arch}, conv={_conv_name(conv)}: "
-            f"ret expected {hex(RET_ADDR)}, got {hex(got_ret)}"
+            f"arch={emu.arch}, conv={_conv_name(conv)}: ret expected {hex(RET_ADDR)}, got {hex(got_ret)}"
         )
         emu.reset_stack(emu.stack_base)
 

--- a/tests/test_func_args.py
+++ b/tests/test_func_args.py
@@ -1,0 +1,104 @@
+import pytest
+
+from speakeasy.config import SpeakeasyConfig
+from speakeasy.windows.win32 import Win32Emulator
+from speakeasy.winenv import arch as e_arch
+
+
+STACK_SIZE = 0x12000
+RET_ADDR = 0xDEADBEEF
+
+
+@pytest.fixture(params=[e_arch.ARCH_X86, e_arch.ARCH_AMD64], ids=["x86", "x64"])
+def emu(config, request):
+    a = request.param
+    cfg = SpeakeasyConfig(**config)
+    e = Win32Emulator(cfg)
+    e.arch = a
+    e.set_ptr_size(a)
+    bits = e_arch.BITS_32 if a == e_arch.ARCH_X86 else e_arch.BITS_64
+    e.emu_eng.init_engine(e_arch.ARCH_X86, bits)
+    base, _ = e.alloc_stack(STACK_SIZE)
+    e.stack_base = base
+    return e
+
+
+X86_CONVS = [e_arch.CALL_CONV_CDECL, e_arch.CALL_CONV_STDCALL, e_arch.CALL_CONV_FASTCALL]
+X64_CONVS = [e_arch.CALL_CONV_CDECL, e_arch.CALL_CONV_STDCALL]
+ARG_COUNTS = [0, 1, 2, 3, 4, 5, 8]
+
+
+def _convs_for_arch(arch):
+    if arch == e_arch.ARCH_X86:
+        return X86_CONVS
+    return X64_CONVS
+
+
+def _conv_name(conv):
+    return {
+        e_arch.CALL_CONV_CDECL: "cdecl",
+        e_arch.CALL_CONV_STDCALL: "stdcall",
+        e_arch.CALL_CONV_FASTCALL: "fastcall",
+    }[conv]
+
+
+def _make_args(argc):
+    return [0x1000 + i for i in range(argc)]
+
+
+@pytest.fixture(autouse=True)
+def _reset_stack(emu):
+    yield
+    emu.reset_stack(emu.stack_base)
+
+
+class TestSetGetFuncArgs:
+    @pytest.mark.parametrize("argc", ARG_COUNTS)
+    def test_round_trip(self, emu, argc):
+        for conv in _convs_for_arch(emu.arch):
+            args = _make_args(argc)
+            emu.set_func_args(emu.stack_base, RET_ADDR, *args, conv=conv)
+            got = emu.get_func_argv(conv, argc)
+            assert got == args, (
+                f"arch={emu.arch}, conv={_conv_name(conv)}, argc={argc}: "
+                f"expected {[hex(a) for a in args]}, got {[hex(a) for a in got]}"
+            )
+            emu.reset_stack(emu.stack_base)
+
+    @pytest.mark.parametrize("argc", ARG_COUNTS)
+    def test_ret_address(self, emu, argc):
+        for conv in _convs_for_arch(emu.arch):
+            args = _make_args(argc)
+            emu.set_func_args(emu.stack_base, RET_ADDR, *args, conv=conv)
+            got_ret = emu.get_ret_address()
+            assert got_ret == RET_ADDR, (
+                f"arch={emu.arch}, conv={_conv_name(conv)}: "
+                f"ret expected {hex(RET_ADDR)}, got {hex(got_ret)}"
+            )
+            emu.reset_stack(emu.stack_base)
+
+
+class TestDoCallReturn:
+    @pytest.mark.parametrize("argc", ARG_COUNTS)
+    def test_x86_stdcall_stack_restored(self, emu, argc):
+        if emu.arch != e_arch.ARCH_X86:
+            pytest.skip("x86 only")
+        conv = e_arch.CALL_CONV_STDCALL
+        args = _make_args(argc)
+        sp_before = emu.get_stack_ptr()
+        emu.set_func_args(emu.stack_base, RET_ADDR, *args, conv=conv)
+        emu.do_call_return(argc, ret_addr=RET_ADDR, conv=conv)
+        sp_after = emu.get_stack_ptr()
+        assert sp_after == sp_before
+
+    @pytest.mark.parametrize("argc", ARG_COUNTS)
+    def test_x86_fastcall_stack_restored(self, emu, argc):
+        if emu.arch != e_arch.ARCH_X86:
+            pytest.skip("x86 only")
+        conv = e_arch.CALL_CONV_FASTCALL
+        args = _make_args(argc)
+        sp_before = emu.get_stack_ptr()
+        emu.set_func_args(emu.stack_base, RET_ADDR, *args, conv=conv)
+        emu.do_call_return(argc, ret_addr=RET_ADDR, conv=conv)
+        sp_after = emu.get_stack_ptr()
+        assert sp_after == sp_before

--- a/tests/test_func_args.py
+++ b/tests/test_func_args.py
@@ -4,7 +4,6 @@ from speakeasy.config import SpeakeasyConfig
 from speakeasy.windows.win32 import Win32Emulator
 from speakeasy.winenv import arch as e_arch
 
-
 STACK_SIZE = 0x12000
 RET_ADDR = 0xDEADBEEF
 


### PR DESCRIPTION
## Summary
- **x86 fastcall**: `set_func_args` now places the first two arguments in ECX/EDX (via new `conv` parameter) instead of pushing all arguments on the stack, matching `get_func_argv(FASTCALL)` and `do_call_return(FASTCALL)`.
- **x64 >4 args**: Reordered stack layout so overflow arguments land above the shadow space (at RSP+0x28, RSP+0x30, …) instead of inside it, matching where `get_func_argv` reads them.
- Added round-trip tests covering `set_func_args` → `get_func_argv` for all arch/conv/argc combinations.

## Test plan
- [x] Round-trip: `set_func_args(args)` → `get_func_argv(conv, len(args))` returns `args` for x86 cdecl/stdcall/fastcall and x64, with argc in {0,1,2,3,4,5,8}
- [x] Return address: `get_ret_address()` returns the value passed to `set_func_args`
- [x] Stack restore: `do_call_return` restores SP for x86 stdcall and fastcall (callee-clean conventions)
- [x] Full existing test suite passes (134 tests)

Closes #298

🤖 Generated with [Claude Code](https://claude.com/claude-code)