### PR TITLE
move handle/id counters to per-emulator HandleAllocator

### DIFF
--- a/speakeasy/windows/cryptman.py
+++ b/speakeasy/windows/cryptman.py
@@ -16,9 +16,8 @@ class CryptContext:
     Represents crypto context used by crypto functions
     """
 
-    curr_handle = 0x680
-
-    def __init__(self, cname, pname, ptype, flags):
+    def __init__(self, allocator, cname, pname, ptype, flags):
+        self.allocator = allocator
         self.container_name = cname
         self.provider_name = pname
         self.ptype = ptype
@@ -26,9 +25,7 @@ class CryptContext:
         self.keys = {}
 
     def get_handle(self):
-        hkey = CryptContext.curr_handle
-        CryptContext.curr_handle += 4
-        return hkey
+        return self.allocator.allocate_crypt_context_handle()
 
     def import_key(self, blob_type=None, blob=None, blob_len=None, hnd_import_key=None, param_list=None, flags=None):
         key = CryptKey(blob_type, blob, blob_len, hnd_import_key, param_list, flags)
@@ -49,13 +46,14 @@ class CryptoManager:
     Manages the emulation of crypto functions
     """
 
-    def __init__(self, config=None):
+    def __init__(self, allocator, config=None):
         super().__init__()
         self.ctx_handles = {}
         self.config = config
+        self.allocator = allocator
 
     def crypt_open(self, cname=None, pname=None, ptype=None, flags=None):
-        ctx = CryptContext(cname, pname, ptype, flags)
+        ctx = CryptContext(self.allocator, cname, pname, ptype, flags)
         hnd = ctx.get_handle()
 
         self.ctx_handles.update({hnd: ctx})

--- a/speakeasy/windows/fileman.py
+++ b/speakeasy/windows/fileman.py
@@ -45,9 +45,8 @@ class FileMap:
     Represents a memory mapped file
     """
 
-    curr_handle = 0x280
-
-    def __init__(self, name, size, prot, backed_file=None):
+    def __init__(self, allocator, name, size, prot, backed_file=None):
+        self.allocator = allocator
         self.name = name
         self.backed_file = backed_file
         self.views = {}
@@ -55,9 +54,7 @@ class FileMap:
         self.prot = prot
 
     def get_handle(self):
-        hmap = FileMap.curr_handle
-        FileMap.curr_handle += 4
-        return hmap
+        return self.allocator.allocate_file_map_handle()
 
     def add_view(self, base, offset, size, protect):
         view = MapView(base, offset, size, protect)
@@ -69,9 +66,8 @@ class File:
     Base class for an emulated file
     """
 
-    curr_handle = 0x80
-
-    def __init__(self, path, config=None, data=b""):
+    def __init__(self, allocator, path, config=None, data=b""):
+        self.allocator = allocator
         self.path: str = path
         self.data: io.BytesIO | bytes | None = None
         self.bytes_written: int = 0
@@ -92,14 +88,12 @@ class File:
         else:
             data = b""
 
-        new = File(self.path, config=self.config, data=data)
+        new = File(self.allocator, self.path, config=self.config, data=data)
         new.is_dir = self.is_dir
         return new
 
     def get_handle(self):
-        hfile = File.curr_handle
-        File.curr_handle += 4
-        return hfile
+        return self.allocator.allocate_file_handle()
 
     def get_hash(self):
         h = hashlib.sha256()
@@ -193,10 +187,8 @@ class Pipe(File):
     Emulated named pipe objects
     """
 
-    curr_handle = 0x400
-
-    def __init__(self, name, mode, num_instances, out_size, in_size, config=None):
-        super().__init__(path=name, config=config)
+    def __init__(self, allocator, name, mode, num_instances, out_size, in_size, config=None):
+        super().__init__(allocator, path=name, config=config)
         self.name = name
         self.mode = mode
         self.num_instances = num_instances
@@ -204,9 +196,7 @@ class Pipe(File):
         self.in_size = in_size
 
     def get_handle(self):
-        hpipe = Pipe.curr_handle
-        Pipe.curr_handle += 4
-        return hpipe
+        return self.allocator.allocate_pipe_handle()
 
 
 class FileManager:
@@ -243,12 +233,12 @@ class FileManager:
     def file_create_mapping(self, hfile, name, size, prot):
         if hfile not in (windefs.INVALID_HANDLE_VALUE, 0):
             f = self.get_file_from_handle(hfile)
-            fm = FileMap(name, size, prot, f)
+            fm = FileMap(self.emu.handle_allocator, name, size, prot, f)
             hnd = fm.get_handle()
             self.file_maps.update({hnd: fm})
             return hnd
         else:
-            fm = FileMap(name, size, prot, None)
+            fm = FileMap(self.emu.handle_allocator, name, size, prot, None)
             hnd = fm.get_handle()
             self.file_maps.update({hnd: fm})
             return hnd
@@ -347,7 +337,7 @@ class FileManager:
         Register an existing file already included in the emulation space
         (with data)
         """
-        f = File(path, data=data)
+        f = File(self.emu.handle_allocator, path, data=data)
         self.files.append(f)
         return f
 
@@ -355,7 +345,7 @@ class FileManager:
         f = self.get_file_from_path(path)
         if f:
             self.files.remove(f)
-        f = File(path)
+        f = File(self.emu.handle_allocator, path)
         self.files.append(f)
         return f
 
@@ -420,7 +410,7 @@ class FileManager:
         fconf = self.get_emu_file(path)
         if not fconf:
             fconf = {}
-        p = Pipe(path, mode, num_instances, out_size, in_size, config=fconf)
+        p = Pipe(self.emu.handle_allocator, path, mode, num_instances, out_size, in_size, config=fconf)
         hnd = p.get_handle()
         self.pipe_handles.update({hnd: p})
         return hnd
@@ -472,12 +462,12 @@ class FileManager:
             if not truncate:
                 if real_path and not os.path.exists(real_path):
                     raise FileSystemEmuError(f"File path not found: {real_path}")
-                f = File(path, config=fconf)
+                f = File(self.emu.handle_allocator, path, config=fconf)
                 self.files.append(f)
             else:
                 if real_path and not os.path.exists(real_path):
                     raise FileSystemEmuError(f"File path not found: {real_path}")
-                f = File(path, config=fconf)
+                f = File(self.emu.handle_allocator, path, config=fconf)
                 self.files.append(f)
             hnd = f.get_handle()
             self.file_handles.update({hnd: f})

--- a/speakeasy/windows/netman.py
+++ b/speakeasy/windows/netman.py
@@ -86,17 +86,12 @@ class WininetComponent:
     Base class used for WinInet connections
     """
 
-    curr_handle = 0x20
     config: Any | None = None
 
-    def __init__(self):
+    def __init__(self, allocator):
         super().__init__()
-        self.handle = self.new_handle()
-
-    def new_handle(self):
-        tmp = WininetComponent.curr_handle
-        WininetComponent.curr_handle += 4
-        return tmp
+        self.allocator = allocator
+        self.handle = self.allocator.allocate_wininet_handle()
 
     def get_handle(self):
         return self.handle
@@ -107,8 +102,8 @@ class WininetRequest(WininetComponent):
     WinInet request object
     """
 
-    def __init__(self, session, verb, objname, ver, ref, accepts, flags, ctx):
-        super().__init__()
+    def __init__(self, allocator, session, verb, objname, ver, ref, accepts, flags, ctx):
+        super().__init__(allocator)
 
         # The WiniNet APIs default to a HTTP "GET" if no verb is specified
         if not verb:
@@ -230,8 +225,8 @@ class WininetRequest(WininetComponent):
 
 
 class WininetSession(WininetComponent):
-    def __init__(self, instance, server, port, user, password, service, flags, ctx):
-        super().__init__()
+    def __init__(self, allocator, instance, server, port, user, password, service, flags, ctx):
+        super().__init__(allocator)
         self.server = server
         self.port = port
         self.user = user
@@ -244,15 +239,15 @@ class WininetSession(WininetComponent):
         self.instance = instance
 
     def new_request(self, verb, objname, ver, ref, accepts, flags, ctx):
-        req = WininetRequest(self, verb, objname, ver, ref, accepts, flags, ctx)
+        req = WininetRequest(self.allocator, self, verb, objname, ver, ref, accepts, flags, ctx)
         hdl = req.get_handle()
         self.requests.update({hdl: req})
         return req
 
 
 class WininetInstance(WininetComponent):
-    def __init__(self, user_agent, access, proxy, bypass, flags):
-        super().__init__()
+    def __init__(self, allocator, user_agent, access, proxy, bypass, flags):
+        super().__init__(allocator)
         self.user_agent = user_agent
         self.access = access
         self.proxy = proxy
@@ -267,7 +262,7 @@ class WininetInstance(WininetComponent):
         self.sessions.update({handle: session})
 
     def new_session(self, server, port, user, password, service, flags, ctx):
-        sess = WininetSession(self, server, port, user, password, service, flags, ctx)
+        sess = WininetSession(self.allocator, self, server, port, user, password, service, flags, ctx)
         hdl = sess.get_handle()
         self.sessions.update({hdl: sess})
         return sess
@@ -278,12 +273,13 @@ class NetworkManager:
     Class that manages network connections during emulation
     """
 
-    def __init__(self, config):
+    def __init__(self, allocator, config):
         super().__init__()
         self.sockets: dict[int, Socket] = {}
         self.wininets: dict[int, WininetInstance] = {}
         self.curr_fd: int = 4
         self.curr_handle: int = 0x20
+        self.allocator = allocator
         self.config: Any = config
         self.dns: Any | None = None
 
@@ -350,7 +346,7 @@ class NetworkManager:
         return None
 
     def new_wininet_inst(self, user_agent, access, proxy, bypass, flags):
-        wini = WininetInstance(user_agent, access, proxy, bypass, flags)
+        wini = WininetInstance(self.allocator, user_agent, access, proxy, bypass, flags)
 
         self.wininets.update({wini.get_handle(): wini})
         return wini

--- a/speakeasy/windows/objman.py
+++ b/speakeasy/windows/objman.py
@@ -10,21 +10,67 @@ import speakeasy.winenv.defs.nt.ntoskrnl as ntoskrnl
 import speakeasy.winenv.defs.windows.windows as windef
 
 
+class HandleAllocator:
+    def __init__(self):
+        self._kernel_object_handle: int = 0x220
+        self._kernel_object_id: int = 0x400
+        self._console_handle: int = 0x340
+        self._gui_object_handle: int = 0x120
+        self._wininet_handle: int = 0x20
+        self._file_handle: int = 0x80
+        self._file_map_handle: int = 0x280
+        self._pipe_handle: int = 0x400
+        self._reg_key_handle: int = 0x180
+        self._crypt_context_handle: int = 0x680
+
+    def _next(self, attr: str) -> int:
+        val = getattr(self, attr)
+        setattr(self, attr, val + 4)
+        return val
+
+    def allocate_kernel_object_handle(self) -> int:
+        return self._next("_kernel_object_handle")
+
+    def allocate_kernel_object_id(self) -> int:
+        return self._next("_kernel_object_id")
+
+    def allocate_console_handle(self) -> int:
+        return self._next("_console_handle")
+
+    def allocate_gui_object_handle(self) -> int:
+        return self._next("_gui_object_handle")
+
+    def allocate_wininet_handle(self) -> int:
+        return self._next("_wininet_handle")
+
+    def allocate_file_handle(self) -> int:
+        return self._next("_file_handle")
+
+    def allocate_file_map_handle(self) -> int:
+        return self._next("_file_map_handle")
+
+    def allocate_pipe_handle(self) -> int:
+        return self._next("_pipe_handle")
+
+    def allocate_reg_key_handle(self) -> int:
+        return self._next("_reg_key_handle")
+
+    def allocate_crypt_context_handle(self) -> int:
+        return self._next("_crypt_context_handle")
+
+
 class Console:
     """
     Represents a console window object
     """
 
-    curr_handle = 0x340
-
-    def __init__(self):
-        self.handle = self.get_handle()
+    def __init__(self, allocator: HandleAllocator):
+        self.allocator = allocator
+        self.handle = self._alloc_handle()
         self.window = 0
 
-    def get_handle(self):
-        tmp = Console.curr_handle
-        Console.curr_handle += 4
-        return tmp
+    def _alloc_handle(self):
+        return self.allocator.allocate_console_handle()
 
 
 class SEH:
@@ -75,9 +121,6 @@ class KernelObject:
     Base class for Kernel objects managed by the object manager
     """
 
-    curr_handle = 0x220
-    curr_id = 0x400
-
     def __init__(self, emu):
         self.emu: Any = emu
         self.address: int | None = None
@@ -86,8 +129,7 @@ class KernelObject:
         self.ref_cnt: int = 0
         self.handles: list[int] = []
         self.arch: int = emu.get_arch()
-        self.id: int = KernelObject.curr_id
-        KernelObject.curr_id += 4
+        self.id: int = emu.handle_allocator.allocate_kernel_object_id()
 
         self.nt_types = ntoskrnl
         self.win_types = windef
@@ -120,8 +162,7 @@ class KernelObject:
         return f"emu.struct.{self.get_class_name()}"
 
     def get_handle(self):
-        tmp = KernelObject.curr_handle
-        KernelObject.curr_handle += 4
+        tmp = self.emu.handle_allocator.allocate_kernel_object_handle()
         self.handles.append(tmp)
         return tmp
 
@@ -532,7 +573,7 @@ class Process(KernelObject):
     def alloc_console(self):
 
         if not self.console:
-            self.console = Console()
+            self.console = Console(self.emu.handle_allocator)
         sm = self.emu.get_session_manager()
         desk = sm.get_current_desktop()
         self.console.window = desk.new_window()
@@ -891,15 +932,12 @@ class ObjectManager:
             return obj.ref_cnt
 
     def get_handle(self, obj):
-        tmp = KernelObject.curr_handle
-        KernelObject.curr_handle += 4
+        tmp = self.emu.handle_allocator.allocate_kernel_object_handle()
         obj.handles.append(tmp)
         return tmp
 
     def new_id(self):
-        _id = KernelObject.curr_id
-        KernelObject.curr_id += 4
-        return _id
+        return self.emu.handle_allocator.allocate_kernel_object_id()
 
     def get_object_from_addr(self, addr):
         return self.objects.get(addr)

--- a/speakeasy/windows/regman.py
+++ b/speakeasy/windows/regman.py
@@ -59,16 +59,13 @@ class RegKey:
     Represents a registry key
     """
 
-    curr_handle = 0x180
-
-    def __init__(self, path):
+    def __init__(self, allocator, path):
+        self.allocator = allocator
         self.path = path
         self.values = []
 
     def get_handle(self):
-        hkey = RegKey.curr_handle
-        RegKey.curr_handle += 4
-        return hkey
+        return self.allocator.allocate_reg_key_handle()
 
     def get_path(self):
         return self.path
@@ -94,12 +91,13 @@ class RegistryManager:
     Manages the emulation of the windows registry. This includes creating keys, subkeys and values
     """
 
-    def __init__(self, config=None):
+    def __init__(self, allocator, config=None):
         super().__init__()
         self.reg_handles = {}
         self.keys = []
         self.config = config
         self.reg_tree = []
+        self.allocator = allocator
 
         for hk in (HKEY_CLASSES_ROOT, HKEY_CURRENT_USER, HKEY_LOCAL_MACHINE, HKEY_USERS):
             path = regdefs.get_hkey_type(hk)
@@ -164,7 +162,7 @@ class RegistryManager:
             return None
         for key in self.config.keys:
             if key.path.lower() == path.lower():
-                new_key = RegKey(path)
+                new_key = RegKey(self.allocator, path)
                 for value in key.values:
                     val_type = value.type
                     vts = regdefs.get_flag_value(val_type)  # noqa
@@ -191,7 +189,7 @@ class RegistryManager:
         if key:
             return key
 
-        key = RegKey(path)
+        key = RegKey(self.allocator, path)
         self.keys.append(key)
         return key
 
@@ -217,7 +215,7 @@ class RegistryManager:
 
         # If we are instructed to create the key, do so
         if create or self.is_key_a_parent_key(path):
-            key = RegKey(path)
+            key = RegKey(self.allocator, path)
             hnd = key.get_handle()
             self.reg_handles.update({hnd: key})
             self.keys.append(key)

--- a/speakeasy/windows/sessman.py
+++ b/speakeasy/windows/sessman.py
@@ -1,6 +1,11 @@
 # Copyright (C) 2020 FireEye, Inc. All Rights Reserved.
 
-from typing import Any
+from __future__ import annotations
+
+from typing import Any, TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from speakeasy.windows.objman import HandleAllocator
 
 
 class GuiObject:
@@ -8,15 +13,15 @@ class GuiObject:
     Base class for all GUI objects
     """
 
-    curr_handle = 0x120
+    def __init__(self, allocator: HandleAllocator):
+        self.allocator = allocator
+        self.handle = self._alloc_handle()
 
-    def __init__(self):
-        self.handle = self.get_handle()
+    def _alloc_handle(self):
+        return self.allocator.allocate_gui_object_handle()
 
     def get_handle(self):
-        tmp = GuiObject.curr_handle
-        GuiObject.curr_handle += 4
-        return tmp
+        return self.handle
 
 
 class Session(GuiObject):
@@ -24,13 +29,13 @@ class Session(GuiObject):
     Represents a windows Session
     """
 
-    def __init__(self, sess_id):
-        super().__init__()
+    def __init__(self, allocator: HandleAllocator, sess_id):
+        super().__init__(allocator)
         self.id: int = sess_id
         self.stations: dict[int, Station] = {}
 
     def new_station(self, name="WinSta0"):
-        stat = Station(name=name)
+        stat = Station(self.allocator, name=name)
         self.stations.update({stat.get_handle(): stat})
         return stat
 
@@ -40,13 +45,13 @@ class Station(GuiObject):
     Represents a window station
     """
 
-    def __init__(self, name=""):
-        super().__init__()
+    def __init__(self, allocator: HandleAllocator, name=""):
+        super().__init__(allocator)
         self.name: str = name
         self.desktops: dict[int, Desktop] = {}
 
     def new_desktop(self, name=""):
-        desk = Desktop(name=name)
+        desk = Desktop(self.allocator, name=name)
         self.desktops.update({desk.get_handle(): desk})
         return desk
 
@@ -56,15 +61,14 @@ class Desktop(GuiObject):
     Represents a Desktop object
     """
 
-    def __init__(self, name=""):
-        super().__init__()
+    def __init__(self, allocator: HandleAllocator, name=""):
+        super().__init__(allocator)
         self.windows: dict[int, Window] = {}
         self.desktop_window: Window = self.new_window()
         self.name: str = name
 
     def new_window(self):
-        # create the desktop window
-        window = Window()
+        window = Window(self.allocator)
         self.windows.update({window.get_handle(): window})
         return window
 
@@ -74,8 +78,8 @@ class Window(GuiObject):
     Represents a GUI window
     """
 
-    def __init__(self, name=None, class_name=None):
-        super().__init__()
+    def __init__(self, allocator: HandleAllocator, name=None, class_name=None):
+        super().__init__(allocator)
         self.name: str | None = name
         self.class_name: str | None = class_name
 
@@ -85,8 +89,8 @@ class WindowClass(GuiObject):
     Represents a GUI window class
     """
 
-    def __init__(self, wclass, name):
-        super().__init__()
+    def __init__(self, allocator: HandleAllocator, wclass, name):
+        super().__init__(allocator)
         self.wclass: Any = wclass
         self.name: str = name
 
@@ -97,7 +101,7 @@ class SessionManager:
     windows, and session isolation
     """
 
-    def __init__(self, config):
+    def __init__(self, config, allocator: HandleAllocator):
         super().__init__()
         self.sessions: dict[int, Session] = {}
         self.window_classes: dict[int | str, WindowClass] = {}
@@ -106,10 +110,11 @@ class SessionManager:
         self.curr_station: Station | None = None
         self.curr_desktop: Desktop | None = None
         self.config: Any = config
-        self.dev_ctx: int = GuiObject.curr_handle
+        self.allocator = allocator
+        self.dev_ctx: int = allocator.allocate_gui_object_handle()
 
         # create a session 0
-        self.curr_session = Session(sess_id=0)
+        self.curr_session = Session(allocator, sess_id=0)
 
         # create WinSta0
         self.curr_station = self.curr_session.new_station(name="WinSta0")
@@ -123,7 +128,7 @@ class SessionManager:
         self.curr_desktop = default
 
     def create_window_class(self, class_obj, class_name=None):
-        wc = WindowClass(class_obj, class_name)
+        wc = WindowClass(self.allocator, class_obj, class_name)
         atom = wc.get_handle()
         self.window_classes.update({atom: wc})
         if class_name:
@@ -131,7 +136,7 @@ class SessionManager:
         return atom
 
     def create_window(self, window_name=None, class_name=None):
-        wc = Window(window_name, class_name)
+        wc = Window(self.allocator, window_name, class_name)
         hnd = wc.get_handle()
         self.windows.update({hnd: wc})
         if window_name:

--- a/speakeasy/windows/sessman.py
+++ b/speakeasy/windows/sessman.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Any, TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
     from speakeasy.windows.objman import HandleAllocator

--- a/speakeasy/windows/win32.py
+++ b/speakeasy/windows/win32.py
@@ -38,7 +38,7 @@ class Win32Emulator(WindowsEmulator):
         self.peb_addr = 0
         self.heap_allocs = []
         self.argv = argv if argv is not None else []
-        self.sessman = SessionManager(config)
+        self.sessman = SessionManager(config, self.handle_allocator)
         self.com = COM(config)
 
     def get_argv(self):

--- a/speakeasy/windows/winemu.py
+++ b/speakeasy/windows/winemu.py
@@ -23,12 +23,12 @@ from speakeasy.profiler_events import TracePosition
 from speakeasy.report import ErrorInfo, RegionInfo
 from speakeasy.struct import EmuStruct
 from speakeasy.windows.cryptman import CryptoManager
-from speakeasy.windows.objman import HandleAllocator
 from speakeasy.windows.driveman import DriveManager
 from speakeasy.windows.fileman import FileManager
 from speakeasy.windows.hammer import ApiHammer
 from speakeasy.windows.loaders import get_prot_string
 from speakeasy.windows.netman import NetworkManager
+from speakeasy.windows.objman import HandleAllocator
 from speakeasy.windows.regman import RegistryManager
 
 # When disassembling, a minimum instruction size needs to be supplied

--- a/speakeasy/windows/winemu.py
+++ b/speakeasy/windows/winemu.py
@@ -23,6 +23,7 @@ from speakeasy.profiler_events import TracePosition
 from speakeasy.report import ErrorInfo, RegionInfo
 from speakeasy.struct import EmuStruct
 from speakeasy.windows.cryptman import CryptoManager
+from speakeasy.windows.objman import HandleAllocator
 from speakeasy.windows.driveman import DriveManager
 from speakeasy.windows.fileman import FileManager
 from speakeasy.windows.hammer import ApiHammer
@@ -148,12 +149,13 @@ class WindowsEmulator(BinaryEmulator):
         self._parse_config(config)
 
         self.wintypes = windef
+        self.handle_allocator: HandleAllocator = HandleAllocator()
         # OS resource managers
-        self.regman: RegistryManager = RegistryManager(self.config.registry)
+        self.regman: RegistryManager = RegistryManager(self.handle_allocator, self.config.registry)
         self.fileman: FileManager = FileManager(config, self)
-        self.netman: NetworkManager = NetworkManager(config=self.config.network)
+        self.netman: NetworkManager = NetworkManager(self.handle_allocator, config=self.config.network)
         self.driveman: DriveManager = DriveManager(config=self.config.drives)
-        self.cryptman: CryptoManager = CryptoManager()
+        self.cryptman: CryptoManager = CryptoManager(self.handle_allocator)
         self.hammer: ApiHammer = ApiHammer(self)
         self._io_manager: Any | None = None
 

--- a/speakeasy/winenv/api/kernelmode/netio.py
+++ b/speakeasy/winenv/api/kernelmode/netio.py
@@ -93,7 +93,7 @@ class Netio(api.ApiHandler):
         self.win = wsk
         self.nt = nt
 
-        self.netman = netman.NetworkManager(config=emu.config.network)
+        self.netman = netman.NetworkManager(emu.handle_allocator, config=emu.config.network)
 
         super().__get_hook_attrs__(self)
 

--- a/speakeasy/winenv/api/usermode/user32.py
+++ b/speakeasy/winenv/api/usermode/user32.py
@@ -46,7 +46,7 @@ class User32(api.ApiHandler):
         self.handles: list[int] = []
         self.wndprocs: dict[int, int] = {}
         self.timer_count: int = 0
-        self.sessman = sessman.SessionManager(config=None)
+        self.sessman = sessman.SessionManager(config=None, allocator=emu.handle_allocator)
         self.synthetic_async_keys = [0x41, 0x42, 0x43]
         self.synthetic_async_key_index = 0
         self.synthetic_hook_keys = [0x41, 0x42, 0x43]

--- a/speakeasy/winenv/api/usermode/winhttp.py
+++ b/speakeasy/winenv/api/usermode/winhttp.py
@@ -35,7 +35,7 @@ class WinHttp(api.ApiHandler):
         self.funcs: dict[str, Any] = {}
         self.data: dict[str, Any] = {}
         self.win: Any | None = None
-        self.netman = netman.NetworkManager(config=emu.config.network)
+        self.netman = netman.NetworkManager(emu.handle_allocator, config=emu.config.network)
         super().__get_hook_attrs__(self)
 
     @apihook("WinHttpOpen", argc=5, conv=_arch.CALL_CONV_STDCALL)

--- a/speakeasy/winenv/api/usermode/wininet.py
+++ b/speakeasy/winenv/api/usermode/wininet.py
@@ -35,7 +35,7 @@ class Wininet(api.ApiHandler):
         self.funcs: dict[str, Any] = {}
         self.data: dict[str, Any] = {}
         self.win: Any | None = None
-        self.netman = netman.NetworkManager(config=emu.config.network)
+        self.netman = netman.NetworkManager(emu.handle_allocator, config=emu.config.network)
         super().__get_hook_attrs__(self)
 
     @apihook("InternetOpen", argc=5, conv=_arch.CALL_CONV_STDCALL)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,37 +7,9 @@ from pathlib import Path
 import pytest
 
 from speakeasy import Speakeasy
-from speakeasy.windows.cryptman import CryptContext
-from speakeasy.windows.fileman import File, FileMap, Pipe
-from speakeasy.windows.netman import WininetComponent
-from speakeasy.windows.objman import Console, KernelObject
-from speakeasy.windows.regman import RegKey
-from speakeasy.windows.sessman import Session
 
 TESTS_DIR = Path(__file__).resolve().parent
 BINS_DIR = TESTS_DIR / "bins"
-
-_HANDLE_DEFAULTS: list[tuple[type, str, int]] = [
-    (File, "curr_handle", 0x80),
-    (FileMap, "curr_handle", 0x280),
-    (Pipe, "curr_handle", 0x400),
-    (RegKey, "curr_handle", 0x180),
-    (Console, "curr_handle", 0x340),
-    (KernelObject, "curr_handle", 0x220),
-    (KernelObject, "curr_id", 0x400),
-    (Session, "curr_handle", 0x120),
-    (CryptContext, "curr_handle", 0x680),
-    (WininetComponent, "curr_handle", 0x20),
-]
-
-
-@pytest.fixture(autouse=True)
-def _reset_handle_counters():
-    for cls, attr, default in _HANDLE_DEFAULTS:
-        setattr(cls, attr, default)
-    yield
-    for cls, attr, default in _HANDLE_DEFAULTS:
-        setattr(cls, attr, default)
 
 
 @pytest.fixture(scope="session")

--- a/tests/test_handle_determinism.py
+++ b/tests/test_handle_determinism.py
@@ -1,0 +1,46 @@
+import pytest
+
+
+@pytest.mark.parametrize("bin_file", ["argv_test_x86.exe.xz"])
+def test_sequential_runs_are_deterministic(config, load_test_bin, bin_file):
+    """Running the same sample twice in one process must produce identical pid/tid."""
+    from speakeasy import Speakeasy
+
+    data = load_test_bin(bin_file)
+
+    def run_once():
+        se = Speakeasy(config=config, argv=[])
+        try:
+            module = se.load_module(data=data)
+            se.run_module(module, all_entrypoints=True)
+            return se.get_report()
+        finally:
+            se.shutdown()
+
+    r1 = run_once()
+    r2 = run_once()
+
+    for ep1, ep2 in zip(r1.entry_points, r2.entry_points):
+        assert ep1.pid == ep2.pid
+        assert ep1.tid == ep2.tid
+
+
+@pytest.mark.parametrize("bin_file", ["argv_test_x86.exe.xz"])
+def test_instances_are_isolated(config, load_test_bin, bin_file):
+    """Two Speakeasy objects must not share handle sequences."""
+    from speakeasy import Speakeasy
+    from speakeasy.windows.objman import HandleAllocator
+
+    data = load_test_bin(bin_file)
+
+    se1 = Speakeasy(config=config, argv=[])
+    se2 = Speakeasy(config=config, argv=[])
+    se1.load_module(data=data)
+    se2.load_module(data=data)
+
+    assert se1.emu.handle_allocator is not se2.emu.handle_allocator
+    assert isinstance(se1.emu.handle_allocator, HandleAllocator)
+    assert isinstance(se2.emu.handle_allocator, HandleAllocator)
+
+    se1.shutdown()
+    se2.shutdown()

--- a/tests/test_profiler_artifacts.py
+++ b/tests/test_profiler_artifacts.py
@@ -7,6 +7,7 @@ from speakeasy.profiler_events import (
     TracePosition,
 )
 from speakeasy.windows.fileman import File
+from speakeasy.windows.objman import HandleAllocator
 
 
 def build_report(profiler: Profiler, run: Run):
@@ -21,7 +22,7 @@ def build_report(profiler: Profiler, run: Run):
 def test_dropped_file_embeds_data_ref_when_within_limit():
     profiler = Profiler()
     run = Run()
-    file_obj = File("C:\\temp\\drop.bin", data=b"payload")
+    file_obj = File(HandleAllocator(), "C:\\temp\\drop.bin", data=b"payload")
 
     profiler.record_dropped_files_event(run, [file_obj])
     report = build_report(profiler, run)
@@ -36,7 +37,7 @@ def test_dropped_file_skips_large_embedded_payload():
     profiler = Profiler()
     run = Run()
     payload = b"A" * ((10 * 1024 * 1024) + 1)
-    file_obj = File("C:\\temp\\large.bin", data=payload)
+    file_obj = File(HandleAllocator(), "C:\\temp\\large.bin", data=payload)
 
     profiler.record_dropped_files_event(run, [file_obj])
     report = build_report(profiler, run)


### PR DESCRIPTION
## Summary
- Introduces `HandleAllocator` class with named allocation methods (`allocate_kernel_object_handle()`, `allocate_file_handle()`, etc.), instantiated once per emulator
- Converts all 10 class-level counters across 9 classes (`KernelObject`, `Console`, `GuiObject`, `WininetComponent`, `File`, `FileMap`, `Pipe`, `RegKey`, `CryptContext`) to use the per-instance allocator
- Threads the allocator as the first constructor parameter to data classes and managers that allocate handles
- Removes the `_reset_handle_counters` autouse fixture from `conftest.py` — no longer needed since state is per-instance

## Test plan
- [x] All 156 existing tests pass (14 skipped — pre-existing missing test files)
- [x] New `test_sequential_runs_are_deterministic`: runs the same sample twice in one process, asserts pid/tid match
- [x] New `test_instances_are_isolated`: creates two `Speakeasy` objects, asserts they have separate `HandleAllocator` instances

Closes #300

🤖 Generated with [Claude Code](https://claude.com/claude-code)