### PR TITLE
fix GetProcAddress ordinal detection and non-PEB module lookup

### DIFF
--- a/speakeasy/windows/objman.py
+++ b/speakeasy/windows/objman.py
@@ -24,7 +24,7 @@ class HandleAllocator:
         self._crypt_context_handle: int = 0x680
 
     def _next(self, attr: str) -> int:
-        val = getattr(self, attr)
+        val: int = getattr(self, attr)
         setattr(self, attr, val + 4)
         return val
 

--- a/speakeasy/winenv/api/usermode/kernel32.py
+++ b/speakeasy/winenv/api/usermode/kernel32.py
@@ -1968,17 +1968,17 @@ class Kernel32(api.ApiHandler):
 
         proc = ""
         if proc_name:
-            try:
-                proc = self.read_mem_string(proc_name, 1)
-                argv[1] = proc
-            except Exception:
-                if isinstance(proc_name, int) and proc_name < 0xFFFF:
-                    # Import is most likely an ordinal
-                    proc = f"ordinal_{proc_name}"
+            if isinstance(proc_name, int) and proc_name < 0x10000:
+                proc = f"ordinal_{proc_name}"
+            else:
+                try:
+                    proc = self.read_mem_string(proc_name, 1)
+                    argv[1] = proc
+                except Exception:
+                    pass
 
         if proc:
-            mods = emu.get_peb_modules()
-            for mod in mods:
+            for mod in emu.modules:
                 if mod.base == hmod:
                     bn = mod.get_base_name()
                     mname, _ = os.path.splitext(bn)


### PR DESCRIPTION
## Summary

- **Ordinal detection**: check `HIWORD(lpProcName) == 0` (i.e. `< 0x10000`) *before* calling `read_mem_string`, matching the documented Windows API convention. Previously the code tried a string read first and only fell back to ordinal in the exception handler, which could misfire when the low address happened to be mapped memory.
- **Module lookup**: search all loaded modules (`emu.modules`) instead of only PEB-visible ones (`get_peb_modules()`), so handles for modules not in the PEB (e.g. runtime-loaded or injected modules) resolve correctly instead of returning NULL.

Closes #303

## Test plan

- [x] Existing `test_get_proc_address` passes
- [x] Full test suite passes (143 passed; 2 pre-existing failures from missing `capa-testfiles`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)