### PR TITLE
fix: normalize_import_miss composition and data-import normalization

### DIFF
--- a/speakeasy/windows/winemu.py
+++ b/speakeasy/windows/winemu.py
@@ -1187,13 +1187,21 @@ class WindowsEmulator(BinaryEmulator):
                 self.add_code_hook(cb=self._module_access_hook, begin=mod_start, end=mod_end)
 
             for imp in image.imports:
-                _api_mod, eh = self.api.get_data_export_handler(imp.dll_name, imp.func_name)
+                dll_name = imp.dll_name
+                alt_dll = winemu.normalize_dll_name(dll_name)
+                _api_mod, eh = self.api.get_data_export_handler(dll_name, imp.func_name)
+                if not eh and alt_dll:
+                    _api_mod, eh = self.api.get_data_export_handler(alt_dll, imp.func_name)
                 if eh:
-                    data_ptr = self.handle_import_data(imp.dll_name, imp.func_name)
-                    sym = f"{imp.dll_name}.{imp.func_name}"
+                    old_sentinel = int.from_bytes(
+                        self.mem_read(imp.iat_address, ptr_size), "little"
+                    )
+                    data_ptr = self.handle_import_data(dll_name, imp.func_name)
+                    sym = f"{dll_name}.{imp.func_name}"
                     self.global_data[imp.iat_address] = [sym, data_ptr]
                     if data_ptr is not None:
                         self.mem_write(imp.iat_address, data_ptr.to_bytes(ptr_size, "little"))
+                    self.import_table.pop(old_sentinel, None)
 
         if is_primary and self.profiler and self.config.analysis.strings and image.regions:
             raw = image.regions[0].data
@@ -1454,7 +1462,13 @@ class WindowsEmulator(BinaryEmulator):
         """
         module, func = self.api.get_data_export_handler(mod_name, sym)  # type: ignore[union-attr]
         if not func:
+            alt_dll = winemu.normalize_dll_name(mod_name)
+            if alt_dll:
+                module, func = self.api.get_data_export_handler(alt_dll, sym)  # type: ignore[union-attr]
+        if not func:
             module, func = self.api.get_export_func_handler(mod_name, sym)  # type: ignore[union-attr]
+            if not func:
+                module, func = self.normalize_import_miss(mod_name, sym)
             if not func:
                 return None
 
@@ -1675,8 +1689,10 @@ class WindowsEmulator(BinaryEmulator):
 
         if alt_imp_api:
             mod, func_attrs = self.api.get_export_func_handler(dll, alt_imp_api)  # type: ignore[union-attr]
-        elif alt_imp_dll:
+        if not func_attrs and alt_imp_dll:
             mod, func_attrs = self.api.get_export_func_handler(alt_imp_dll, name)  # type: ignore[union-attr]
+        if not func_attrs and alt_imp_dll and alt_imp_api:
+            mod, func_attrs = self.api.get_export_func_handler(alt_imp_dll, alt_imp_api)  # type: ignore[union-attr]
         return mod, func_attrs
 
     def read_unicode_string(self, addr):

--- a/tests/test_import_normalization.py
+++ b/tests/test_import_normalization.py
@@ -1,0 +1,152 @@
+"""Test that DLL-name normalization and A/W (Zw/Nt) folding compose in normalize_import_miss."""
+
+import pytest
+
+from speakeasy.windows.common import normalize_dll_name
+
+SENTINEL_HANDLER = ("handler", lambda: None, 4, "stdcall", None)
+
+
+class HandlerTable:
+    """Concrete handler lookup that resolves a fixed set of (dll, func) pairs."""
+
+    def __init__(self, entries):
+        self._entries = {(d.lower(), f): SENTINEL_HANDLER for d, f in entries}
+
+    def get_export_func_handler(self, dll, name):
+        key = (dll.lower() if dll else dll, name)
+        handler = self._entries.get(key)
+        return (self, handler) if handler else (None, None)
+
+    def get_data_export_handler(self, dll, name):
+        return None, None
+
+
+class FakeEmulator:
+    """Minimal object satisfying normalize_import_miss's self.api contract."""
+
+    def __init__(self, handler_entries):
+        self.api = HandlerTable(handler_entries)
+
+    def normalize_import_miss(self, dll, name):
+        from speakeasy.windows.winemu import WindowsEmulator
+
+        return WindowsEmulator.normalize_import_miss(self, dll, name)
+
+
+CANONICAL_HANDLERS = [
+    ("kernel32", "CreateProcess"),
+    ("kernel32", "LoadLibraryEx"),
+    ("kernel32", "GetModuleFileName"),
+    ("kernel32", "SetLastError"),
+    ("msvcrt", "malloc"),
+    ("ws2_32", "connect"),
+    ("ntoskrnl", "ZwCreateFile"),
+    ("ntoskrnl", "NtQueryInformationProcess"),
+]
+
+
+@pytest.fixture
+def emu():
+    return FakeEmulator(CANONICAL_HANDLERS)
+
+
+def test_normalize_dll_name_apiset_core():
+    assert normalize_dll_name("api-ms-win-core-processthreads-l1-1-1") == "kernel32"
+
+
+def test_normalize_dll_name_crt():
+    assert normalize_dll_name("api-ms-win-crt-heap-l1-1-0") == "msvcrt"
+    assert normalize_dll_name("vcruntime140") == "msvcrt"
+    assert normalize_dll_name("ucrtbase") == "msvcrt"
+
+
+def test_normalize_dll_name_winsock():
+    assert normalize_dll_name("wsock32") == "ws2_32"
+    assert normalize_dll_name("winsock") == "ws2_32"
+
+
+def test_normalize_dll_name_no_change():
+    assert normalize_dll_name("kernel32") == "kernel32"
+    assert normalize_dll_name("ntdll") == "ntdll"
+
+
+@pytest.mark.parametrize(
+    "dll, func",
+    [
+        ("kernel32", "CreateProcess"),
+        ("kernel32", "CreateProcessA"),
+        ("kernel32", "CreateProcessW"),
+        ("api-ms-win-core-processthreads-l1-1-1", "CreateProcess"),
+        ("api-ms-win-core-processthreads-l1-1-1", "CreateProcessA"),
+        ("api-ms-win-core-processthreads-l1-1-1", "CreateProcessW"),
+    ],
+)
+def test_apiset_with_aw_suffix(emu, dll, func):
+    _mod, attrs = emu.normalize_import_miss(dll, func)
+    assert attrs is not None, f"({dll}, {func}) should resolve"
+
+
+@pytest.mark.parametrize(
+    "dll, func",
+    [
+        ("api-ms-win-core-libraryloader-l1-2-0", "LoadLibraryEx"),
+        ("api-ms-win-core-libraryloader-l1-2-0", "LoadLibraryExA"),
+        ("api-ms-win-core-libraryloader-l1-2-0", "LoadLibraryExW"),
+    ],
+)
+def test_apiset_libraryloader(emu, dll, func):
+    _mod, attrs = emu.normalize_import_miss(dll, func)
+    assert attrs is not None, f"({dll}, {func}) should resolve"
+
+
+@pytest.mark.parametrize(
+    "dll, func",
+    [
+        ("api-ms-win-crt-heap-l1-1-0", "malloc"),
+        ("vcruntime140", "malloc"),
+        ("ucrtbase", "malloc"),
+    ],
+)
+def test_crt_normalization(emu, dll, func):
+    _mod, attrs = emu.normalize_import_miss(dll, func)
+    assert attrs is not None, f"({dll}, {func}) should resolve"
+
+
+@pytest.mark.parametrize(
+    "dll, func",
+    [
+        ("wsock32", "connect"),
+        ("winsock", "connect"),
+    ],
+)
+def test_winsock_normalization(emu, dll, func):
+    _mod, attrs = emu.normalize_import_miss(dll, func)
+    assert attrs is not None, f"({dll}, {func}) should resolve"
+
+
+def test_unresolvable_returns_none(emu):
+    _mod, attrs = emu.normalize_import_miss("unknown", "NoSuchFunc")
+    assert attrs is None
+
+
+@pytest.mark.parametrize(
+    "func, expected_func",
+    [
+        ("ZwCreateFile", "ZwCreateFile"),
+        ("NtCreateFile", "ZwCreateFile"),
+    ],
+)
+def test_ntdll_to_ntoskrnl(emu, func, expected_func):
+    _mod, attrs = emu.normalize_import_miss("ntdll", func)
+    assert attrs is not None, f"ntdll.{func} should bridge to ntoskrnl.{expected_func}"
+
+
+def test_ntoskrnl_zw_to_nt(emu):
+    _mod, attrs = emu.normalize_import_miss("ntoskrnl", "ZwQueryInformationProcess")
+    assert attrs is not None, "ntoskrnl.ZwQueryInformationProcess -> NtQueryInformationProcess"
+
+
+def test_ntoskrnl_direct(emu):
+    _mod, attrs = emu.normalize_import_miss("ntoskrnl", "ZwCreateFile")
+    assert attrs is not None


### PR DESCRIPTION
## Summary
- **normalize_import_miss** used mutually exclusive `if`/`elif` branches for A/W suffix stripping and DLL-name normalization (apiset/CRT/winsock → kernel32/msvcrt/ws2_32). When both transformations applied (e.g. `api-ms-win-core-processthreads-l1-1-1.CreateProcessA`), only the suffix branch ran with the original un-normalized DLL, so the handler was never found. Changed to a fallthrough that tries `(dll, alt_name)`, `(alt_dll, name)`, and `(alt_dll, alt_name)`.
- **handle_import_data** and the load-time data-import loop had the same normalization gap — raw DLL names were never normalized, so data imports via apiset/CRT names were silently uninitialized. Added `normalize_dll_name` fallback to both.
- **Orphaned sentinels:** when data imports overwrite an IAT slot, the sentinel previously allocated for that slot is now removed from `import_table`.

Closes #301
Closes #302

## Test plan
- [x] 23 new parametrized tests in `test_import_normalization.py` covering apiset/CRT/winsock × {base, A, W} and ntdll/ntoskrnl Zw/Nt bridging
- [x] Full test suite passes (181 passed, 14 skipped — pre-existing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)