### PR TITLE
Reset CPU registers, EFLAGS, and stack memory between runs

### DIFF
--- a/speakeasy/binemu.py
+++ b/speakeasy/binemu.py
@@ -591,6 +591,43 @@ class BinaryEmulator(MemoryManager, ABC):
             raise EmuException("Unsupported architecture")
         return val
 
+    def reset_cpu_context(self):
+        """
+        Zero general-purpose registers and reset EFLAGS to the default value (0x2).
+
+        Does NOT touch SP, BP, or IP — those are managed by reset_stack / run setup.
+        """
+        arch = self.get_arch()
+        if arch == e_arch.ARCH_X86:
+            for reg in (
+                e_arch.X86_REG_EAX,
+                e_arch.X86_REG_EBX,
+                e_arch.X86_REG_ECX,
+                e_arch.X86_REG_EDX,
+                e_arch.X86_REG_ESI,
+                e_arch.X86_REG_EDI,
+            ):
+                self.reg_write(reg, 0)
+        elif arch == e_arch.ARCH_AMD64:
+            for reg in (
+                e_arch.AMD64_REG_RAX,
+                e_arch.AMD64_REG_RBX,
+                e_arch.AMD64_REG_RCX,
+                e_arch.AMD64_REG_RDX,
+                e_arch.AMD64_REG_RSI,
+                e_arch.AMD64_REG_RDI,
+                e_arch.AMD64_REG_R8,
+                e_arch.AMD64_REG_R9,
+                e_arch.AMD64_REG_R10,
+                e_arch.AMD64_REG_R11,
+                e_arch.AMD64_REG_R12,
+                e_arch.AMD64_REG_R13,
+                e_arch.AMD64_REG_R14,
+                e_arch.AMD64_REG_R15,
+            ):
+                self.reg_write(reg, 0)
+        self.reg_write(e_arch.X86_REG_EFLAGS, 0x2)
+
     def reset_stack(self, base):
         """
         Reset stack to the supplied base address

--- a/speakeasy/windows/winemu.py
+++ b/speakeasy/windows/winemu.py
@@ -418,6 +418,9 @@ class WindowsEmulator(BinaryEmulator):
         self._seh_last_fault = None
         self._seh_repeat_count = 0
         self.reset_stack(self.stack_base)
+        self.reset_cpu_context()
+        mm = self.get_address_map(self.stack_base - 1)
+        self.mem_write(mm.base, b"\x00" * mm.size)
         return self._prepare_run_context(run)
 
     def call(self, addr, params=[]):
@@ -425,6 +428,9 @@ class WindowsEmulator(BinaryEmulator):
         Start emulating at the specified address
         """
         self.reset_stack(self.stack_base)
+        self.reset_cpu_context()
+        mm = self.get_address_map(self.stack_base - 1)
+        self.mem_write(mm.base, b"\x00" * mm.size)
         run = Run()
         run.type = f"call_0x{addr:x}"
         run.start_addr = addr
@@ -1193,9 +1199,7 @@ class WindowsEmulator(BinaryEmulator):
                 if not eh and alt_dll:
                     _api_mod, eh = self.api.get_data_export_handler(alt_dll, imp.func_name)
                 if eh:
-                    old_sentinel = int.from_bytes(
-                        self.mem_read(imp.iat_address, ptr_size), "little"
-                    )
+                    old_sentinel = int.from_bytes(self.mem_read(imp.iat_address, ptr_size), "little")
                     data_ptr = self.handle_import_data(dll_name, imp.func_name)
                     sym = f"{dll_name}.{imp.func_name}"
                     self.global_data[imp.iat_address] = [sym, data_ptr]

--- a/tests/test_run_isolation.py
+++ b/tests/test_run_isolation.py
@@ -1,0 +1,119 @@
+import pytest
+
+import speakeasy.winenv.arch as e_arch
+from speakeasy import Speakeasy
+
+
+@pytest.mark.parametrize(
+    "bin_file,arch",
+    [
+        ("dll_test_x86.dll.xz", e_arch.ARCH_X86),
+        ("dll_test_x64.dll.xz", e_arch.ARCH_AMD64),
+    ],
+)
+def test_registers_reset_between_runs(config, load_test_bin, bin_file, arch):
+    """Each run must start with zeroed GP registers and DF=0."""
+    data = load_test_bin(bin_file)
+    se = Speakeasy(config=config, argv=[])
+    module = se.load_module(data=data)
+
+    run_register_snapshots = []
+    seen_runs = set()
+
+    if arch == e_arch.ARCH_X86:
+        gp_regs = [
+            e_arch.X86_REG_EAX,
+            e_arch.X86_REG_EBX,
+            e_arch.X86_REG_ECX,
+            e_arch.X86_REG_EDX,
+            e_arch.X86_REG_ESI,
+            e_arch.X86_REG_EDI,
+        ]
+    else:
+        gp_regs = [
+            e_arch.AMD64_REG_RAX,
+            e_arch.AMD64_REG_RBX,
+            e_arch.AMD64_REG_RCX,
+            e_arch.AMD64_REG_RDX,
+            e_arch.AMD64_REG_RSI,
+            e_arch.AMD64_REG_RDI,
+            e_arch.AMD64_REG_R8,
+            e_arch.AMD64_REG_R9,
+            e_arch.AMD64_REG_R10,
+            e_arch.AMD64_REG_R11,
+            e_arch.AMD64_REG_R12,
+            e_arch.AMD64_REG_R13,
+            e_arch.AMD64_REG_R14,
+            e_arch.AMD64_REG_R15,
+        ]
+
+    def code_hook(emu, addr, size):
+        run_id = id(se.emu.curr_run)
+        if run_id not in seen_runs:
+            seen_runs.add(run_id)
+            snapshot = {}
+            for reg in gp_regs:
+                snapshot[reg] = se.emu.reg_read(reg)
+            eflags = se.emu.reg_read(e_arch.X86_REG_EFLAGS)
+            snapshot["df"] = bool(eflags & (1 << 10))
+            run_register_snapshots.append(snapshot)
+
+    se.emu.add_code_hook(cb=code_hook)
+    se.run_module(module, all_entrypoints=True)
+    se.shutdown()
+
+    assert len(run_register_snapshots) > 1, "Need multiple runs to test isolation"
+
+    for i, snapshot in enumerate(run_register_snapshots[1:], 1):
+        if arch == e_arch.ARCH_X86:
+            for reg in gp_regs:
+                assert snapshot[reg] == 0, f"Run {i}: register should be 0, got {snapshot[reg]:#x}"
+        else:
+            non_arg_regs = [
+                e_arch.AMD64_REG_RAX,
+                e_arch.AMD64_REG_RBX,
+                e_arch.AMD64_REG_RSI,
+                e_arch.AMD64_REG_RDI,
+                e_arch.AMD64_REG_R10,
+                e_arch.AMD64_REG_R11,
+                e_arch.AMD64_REG_R12,
+                e_arch.AMD64_REG_R13,
+                e_arch.AMD64_REG_R14,
+                e_arch.AMD64_REG_R15,
+            ]
+            for reg in non_arg_regs:
+                assert snapshot[reg] == 0, f"Run {i}: register should be 0, got {snapshot[reg]:#x}"
+        assert not snapshot["df"], f"Run {i}: DF should be clear"
+
+
+@pytest.mark.parametrize("bin_file", ["dll_test_x86.dll.xz"])
+def test_stack_cleared_between_runs(config, load_test_bin, bin_file):
+    """Stack memory must be zeroed at the start of each run."""
+    data = load_test_bin(bin_file)
+    se = Speakeasy(config=config, argv=[])
+    module = se.load_module(data=data)
+
+    stack_snapshots = []
+    seen_runs = set()
+    SAMPLE_SIZE = 256
+
+    def code_hook(emu, addr, size):
+        run_id = id(se.emu.curr_run)
+        if run_id not in seen_runs:
+            seen_runs.add(run_id)
+            sp = se.emu.get_stack_ptr()
+            try:
+                data_below = se.emu.mem_read(sp - SAMPLE_SIZE, SAMPLE_SIZE)
+                stack_snapshots.append(bytes(data_below))
+            except Exception:
+                stack_snapshots.append(None)
+
+    se.emu.add_code_hook(cb=code_hook)
+    se.run_module(module, all_entrypoints=True)
+    se.shutdown()
+
+    assert len(stack_snapshots) > 1
+
+    for i, snap in enumerate(stack_snapshots[1:], 1):
+        if snap is not None:
+            assert snap == b"\x00" * SAMPLE_SIZE, f"Run {i}: stack below SP should be zeroed"


### PR DESCRIPTION
## Summary
- Zero all general-purpose registers (EAX-EDI on x86, RAX-R15 on x64) and reset EFLAGS to 0x2 between runs
- Clear stack memory contents between runs (not just the stack pointer)
- Prevents state bleed across entry points/threads when using `all_entrypoints=True`

Previously, only ESP/EBP were reset between runs. The remaining CPU state (GP registers, EFLAGS, stack contents) was inherited from the prior run. This caused silent corruption (e.g., DF bleed breaking `rep movs`), order-dependent results, and non-reproducible reports.

Closes #304
Closes #305

## Test plan
- [x] New `test_registers_reset_between_runs` (x86 + x64): hooks first instruction of each run, asserts GP registers are zeroed and DF is clear
- [x] New `test_stack_cleared_between_runs`: asserts 256 bytes below SP are zeroed at the start of each subsequent run
- [x] Full test suite passes (141 passed, 14 skipped; 2 pre-existing failures from missing capa-testfiles)

🤖 Generated with [Claude Code](https://claude.com/claude-code)