### PR TITLE
fix curr_mod not refreshed on in-hook run transitions

### DIFF
--- a/speakeasy/windows/winemu.py
+++ b/speakeasy/windows/winemu.py
@@ -449,6 +449,7 @@ class WindowsEmulator(BinaryEmulator):
         logger.info("* exec: %s", run.type)
 
         self.curr_run = run
+        self.curr_mod = self.get_module_from_addr(run.start_addr)
         if self.profiler:
             self.profiler.add_run(run)
 
@@ -616,7 +617,6 @@ class WindowsEmulator(BinaryEmulator):
 
         while True:
             try:
-                self.curr_mod = self.get_module_from_addr(self.curr_run.start_addr)  # type: ignore[union-attr]
                 if debugger is not None:
                     resume_addr = self.get_pc()
                 else:


### PR DESCRIPTION
## Summary
- Refresh `curr_mod` from `run.start_addr` in `_prepare_run_context` so every run — whether entered via `start()` or `_exec_next_run()` — has the correct current module before any hooks fire.
- Remove the now-redundant `curr_mod` assignment at the top of `_execute_runs`'s while loop, since `_prepare_run_context` always runs first.

Previously, `curr_mod` was only set inside the `_execute_runs` loop. In-hook run transitions via `_exec_next_run` → `_prepare_run_context` never refreshed it, so `handle_import_func` could consult the wrong module's import table when control transferred to a different module.

Closes #306

🤖 Generated with [Claude Code](https://claude.com/claude-code)