### PR TITLE
Ntoskrnl and crt api additions

### DIFF
--- a/speakeasy/winenv/api/api.py
+++ b/speakeasy/winenv/api/api.py
@@ -425,6 +425,8 @@ class ApiHandler:
 
         # Very brittle format string parser, should improve later
         inside_fmt = False
+        # Characters spliced out of new so far; every positional edit below must subtract it
+        removed = 0
         for i, c in enumerate(string):
             if c == "%":
                 if inside_fmt:
@@ -436,13 +438,13 @@ class ApiHandler:
                 if c == "S":
                     s = self.read_wide_string(args.pop(0))
                     new_fmts.append(s)
-                    new[i] = "s"
+                    new[i - removed] = "s"
                     inside_fmt = False
 
                 elif c == "s":
                     if curr_fmt.startswith("w"):
                         s = self.read_wide_string(args.pop(0))
-                        new[i - 1] = "\xff"
+                        new[i - 1 - removed] = "\xff"
                         curr_fmt = ""
                         new_fmts.append(s)
                     else:
@@ -456,19 +458,32 @@ class ApiHandler:
                             low = args.pop(0)
                             high = args.pop(0)
                             new_fmts.append(high << 32 | low)
-                        new = new[: i - 2] + new[i:]
+                        start = i - removed
+                        new = new[: start - 2] + new[start:]
+                        removed += 2
+                        curr_fmt = ""
+                    elif curr_fmt.startswith(("z", "j", "t")):
+                        if self.get_ptr_size() == 8:
+                            new_fmts.append(args.pop(0))
+                        else:
+                            new_fmts.append(0xFFFFFFFF & args.pop(0))
+                        start = i - removed
+                        new = new[: start - 1] + new[start:]
+                        removed += 1
                         curr_fmt = ""
                     else:
                         new_fmts.append(0xFFFFFFFF & args.pop(0))
                 elif c == "c":
                     new_fmts.append(0xFF & args.pop(0))
                 elif c == "P":
-                    new[i] = "X"
+                    new[i - removed] = "X"
                     new_fmts.append(args.pop(0))
                 elif c == "p":
-                    new[i] = "x"
+                    new[i - removed] = "x"
                     new_fmts.append(args.pop(0))
                 elif c == "l":
+                    curr_fmt += c
+                elif c in ("z", "j", "t"):
                     curr_fmt += c
                 elif c == "w":
                     curr_fmt += c

--- a/speakeasy/winenv/api/kernelmode/ntoskrnl.py
+++ b/speakeasy/winenv/api/kernelmode/ntoskrnl.py
@@ -366,6 +366,33 @@ class Ntoskrnl(api.ApiHandler):
         chunk = self.pool_alloc(PoolType, NumberOfBytes, "None")
         return chunk
 
+    @apihook("ExAllocatePool2", argc=3)
+    def ExAllocatePool2(self, emu, argv, ctx: api.ApiContext = None):
+        """
+        NTKERNELAPI PVOID ExAllocatePool2(
+            FLAGS Flags,
+            SIZE_T Size,
+            ULONG Tag
+            );
+        """
+        Flags, Size, Tag = argv
+
+        if Tag:
+            try:
+                Tag = Tag.to_bytes(4, "little").decode("utf-8")
+            except Exception as e:
+                logger.exception(str(e))
+            argv[2] = Tag
+
+        if not Size:
+            return 0
+
+        pool_flag_paged = 0x100
+        pool_type = ddk.POOL_TYPE.PagedPool if Flags & pool_flag_paged else ddk.POOL_TYPE.NonPagedPool
+
+        chunk = self.pool_alloc(pool_type, Size, Tag)
+        return chunk
+
     @apihook("ExFreePool", argc=1)
     def ExFreePool(self, emu, argv, ctx: api.ApiContext = None):
         """
@@ -2406,6 +2433,18 @@ class Ntoskrnl(api.ApiHandler):
         p = emu.get_current_process()
         return p.address
 
+    @apihook("PsGetCurrentProcessId", argc=0)
+    def PsGetCurrentProcessId(self, emu, argv, ctx: api.ApiContext = None):
+        """
+        HANDLE PsGetCurrentProcessId(
+            void
+        );
+        """
+
+        p = emu.get_current_process()
+        pid = getattr(p, "pid", None)
+        return pid if pid is not None else 4
+
     @apihook("NtSetInformationThread", argc=4)
     def NtSetInformationThread(self, emu, argv, ctx: api.ApiContext = None):
         """
@@ -2469,6 +2508,48 @@ class Ntoskrnl(api.ApiHandler):
         irql = self.get_current_irql()
         self.set_current_irql(ddk.DISPATCH_LEVEL)
         return irql
+
+    @apihook("KeInitializeSpinLock", argc=1)
+    def KeInitializeSpinLock(self, emu, argv, ctx: api.ApiContext = None):
+        """
+        VOID KeInitializeSpinLock(
+        _Out_ PKSPIN_LOCK SpinLock
+        );
+        """
+        (spinlock,) = argv
+        if spinlock:
+            self.mem_write(spinlock, b"\x00" * emu.get_ptr_size())
+        return
+
+    @apihook("KeAcquireSpinLock", argc=2)
+    def KeAcquireSpinLock(self, emu, argv, ctx: api.ApiContext = None):
+        """
+        VOID KeAcquireSpinLock(
+        _Inout_ PKSPIN_LOCK SpinLock,
+        _Out_   PKIRQL      OldIrql
+        );
+        """
+        spinlock, old_irql = argv
+        irql = self.get_current_irql()
+        if old_irql:
+            self.mem_write(old_irql, bytes([irql]))
+        self.set_current_irql(ddk.DISPATCH_LEVEL)
+        return
+
+    @apihook("KeReleaseSpinLock", argc=2)
+    def KeReleaseSpinLock(self, emu, argv, ctx: api.ApiContext = None):
+        """
+        VOID KeReleaseSpinLock(
+        _Inout_ PKSPIN_LOCK SpinLock,
+        _In_    KIRQL       NewIrql
+        );
+        """
+        spinlock, new_irql = argv
+        if new_irql:
+            self.set_current_irql(new_irql & 0xFF)
+        else:
+            self.set_current_irql(ddk.PASSIVE_LEVEL)
+        return
 
     @apihook("MmUnlockPages", argc=1)
     def MmUnlockPages(self, emu, argv, ctx: api.ApiContext = None):

--- a/tests/test_do_str_format.py
+++ b/tests/test_do_str_format.py
@@ -1,0 +1,87 @@
+"""Unit tests for ApiHandler.do_str_format printf-style emulation."""
+
+import pytest
+
+from speakeasy.winenv.api.api import ApiHandler
+
+
+class FakeFormatApi:
+    def __init__(self, ptr_size=8):
+        self.ptr_size = ptr_size
+        self.strings: dict[int, bytes] = {}
+
+    def get_ptr_size(self):
+        return self.ptr_size
+
+    def read_string(self, addr, max_chars=0):
+        return self.strings[addr].decode("utf-8")
+
+    def read_wide_string(self, addr, max_chars=0):
+        return self.strings[addr].decode("utf-16le")
+
+
+@pytest.fixture
+def api():
+    return FakeFormatApi(ptr_size=8)
+
+
+def do_format(api, string, args):
+    return ApiHandler.do_str_format(api, string, list(args))
+
+
+def test_c99_z_modifier_consumes_full_arg_on_x64(api):
+    assert do_format(api, "%zu", [0x1122334455667788]) == str(0x1122334455667788)
+    assert do_format(api, "%zx", [0xAABBCCDDEEFF1122]) == "aabbccddeeff1122"
+
+
+def test_c99_z_modifier_masks_to_32_bits_on_x86():
+    api = FakeFormatApi(ptr_size=4)
+
+    assert do_format(api, "%zu", [0x1122334455667788]) == str(0x55667788)
+
+
+@pytest.mark.parametrize(
+    "fmt,value,expected",
+    [
+        ("%ju", 0x1000, "4096"),
+        ("%td", 7, "7"),
+        ("%ti", 9, "9"),
+    ],
+    ids=["ju", "td", "ti"],
+)
+def test_c99_j_and_t_modifiers_format_value(api, fmt, value, expected):
+    assert do_format(api, fmt, [value]) == expected
+
+
+def test_multiple_ll_conversions_keep_output_index_correct(api):
+    assert do_format(api, "%llx %llx", [0x1111, 0x2222]) == "1111 2222"
+
+
+def test_narrow_string_after_z_splice_formats_both_args(api):
+    api.strings[0x500000] = b"hello"
+
+    assert do_format(api, "%zu %s", [42, 0x500000]) == "42 hello"
+
+
+def test_p_conversion_after_z_splice_lands_in_correct_slot(api):
+    assert do_format(api, "%zu %p", [42, 0xDEADBEEF]) == "42 deadbeef"
+
+
+def test_upper_p_conversion_after_ll_splice_lands_in_correct_slot(api):
+    assert do_format(api, "%llx %P", [0xAB, 0xDEADBEEF]) == "ab DEADBEEF"
+
+
+def test_S_conversion_after_ll_splice_lands_in_correct_slot(api):
+    api.strings[0x600000] = "wide".encode("utf-16le")
+
+    assert do_format(api, "%llx %S", [0xAB, 0x600000]) == "ab wide"
+
+
+def test_wide_s_after_ll_splice_lands_in_correct_slot(api):
+    api.strings[0x600000] = "wide".encode("utf-16le")
+
+    assert do_format(api, "%llx %ws", [0xAB, 0x600000]) == "ab wide"
+
+
+def test_percent_escapes_are_preserved(api):
+    assert do_format(api, "100%% %zu", [7]) == "100% 7"

--- a/tests/test_ntoskrnl_api.py
+++ b/tests/test_ntoskrnl_api.py
@@ -1,0 +1,173 @@
+"""Unit tests for ntoskrnl spinlock, pool allocation and current-pid APIs."""
+
+import pytest
+
+import speakeasy.winenv.arch as _arch
+import speakeasy.winenv.defs.nt.ddk as ddk
+from speakeasy.winenv.api.kernelmode.ntoskrnl import Ntoskrnl
+
+TEST_POOL_BASE = 0x1000000
+
+
+class FakeProcess:
+    def __init__(self, pid):
+        self.pid = pid
+
+
+class FakeKernelEmu:
+    """
+    Minimal emulator seam exposing only what the Ntoskrnl handlers under test
+    reach through self.emu.
+    """
+
+    def __init__(self, ptr_size=8):
+        if ptr_size == 8:
+            self._arch = _arch.ARCH_AMD64
+        elif ptr_size == 4:
+            self._arch = _arch.ARCH_X86
+        else:
+            raise ValueError(f"Unsupported pointer size: {ptr_size}")
+        self.ptr_size = ptr_size
+        self.mem: dict[int, int] = {}
+        self.irql = ddk.PASSIVE_LEVEL
+        self.process = None
+        self.pool_allocs: list[tuple[int, int, str]] = []
+
+    def get_arch(self):
+        return self._arch
+
+    def get_ptr_size(self):
+        return self.ptr_size
+
+    def get_current_irql(self):
+        return self.irql
+
+    def set_current_irql(self, irql):
+        self.irql = irql
+
+    def get_current_process(self):
+        return self.process
+
+    def get_address_map(self, addr):
+        # No bookkeeping maps in the fake: mem_write takes the direct path.
+        return None
+
+    def mem_write(self, addr, data):
+        for i, byte in enumerate(data):
+            self.mem[addr + i] = byte
+
+    def mem_read(self, addr, size):
+        return bytes(self.mem.get(addr + i, 0) for i in range(size))
+
+    def pool_alloc(self, pool_type, size, tag):
+        chunk = TEST_POOL_BASE + len(self.pool_allocs) * 0x1000
+        self.pool_allocs.append((pool_type, size, tag))
+        return chunk
+
+
+@pytest.fixture(params=[8, 4], ids=["x64", "x86"])
+def emu(request):
+    return FakeKernelEmu(ptr_size=request.param)
+
+
+def make_api(emu):
+    return Ntoskrnl(emu)
+
+
+@pytest.mark.parametrize("ptr_size", [8, 4], ids=["x64", "x86"])
+def test_ke_initialize_spin_lock_zeroes_the_lock(ptr_size):
+    emu = FakeKernelEmu(ptr_size=ptr_size)
+    api = make_api(emu)
+    lock = 0x4000
+    emu.mem_write(lock, b"\xaa" * emu.get_ptr_size())
+
+    api.KeInitializeSpinLock(emu, [lock])
+
+    assert emu.mem_read(lock, emu.get_ptr_size()) == b"\x00" * emu.get_ptr_size()
+
+
+def test_ke_acquire_spin_lock_saves_old_irql_and_raises_to_dispatch(emu):
+    api = make_api(emu)
+    lock = 0x4000
+    old_irql = 0x5000
+    emu.set_current_irql(ddk.PASSIVE_LEVEL)
+
+    api.KeAcquireSpinLock(emu, [lock, old_irql])
+
+    assert emu.mem_read(old_irql, 1) == bytes([ddk.PASSIVE_LEVEL])
+    assert emu.get_current_irql() == ddk.DISPATCH_LEVEL
+
+
+def test_ke_acquire_spin_lock_at_dispatch_stays_at_dispatch(emu):
+    # Documented simplification: acquisition always raises to DISPATCH_LEVEL,
+    # even when starting there (matches the existing Kf* hook behavior).
+    api = make_api(emu)
+    lock = 0x4000
+    old_irql = 0x5000
+    emu.set_current_irql(ddk.DISPATCH_LEVEL)
+
+    api.KeAcquireSpinLock(emu, [lock, old_irql])
+
+    assert emu.mem_read(old_irql, 1) == bytes([ddk.DISPATCH_LEVEL])
+    assert emu.get_current_irql() == ddk.DISPATCH_LEVEL
+
+
+def test_ke_release_spin_lock_restores_new_irql(emu):
+    api = make_api(emu)
+    lock = 0x4000
+    emu.set_current_irql(ddk.DISPATCH_LEVEL)
+
+    api.KeReleaseSpinLock(emu, [lock, ddk.DISPATCH_LEVEL])
+    assert emu.get_current_irql() == ddk.DISPATCH_LEVEL
+
+    api.KeReleaseSpinLock(emu, [lock, 0])
+    assert emu.get_current_irql() == ddk.PASSIVE_LEVEL
+
+
+def test_ex_allocate_pool2_decodes_tag_and_paged_flag(emu):
+    api = make_api(emu)
+    tag = int.from_bytes(b"Face", "little")
+
+    chunk = api.ExAllocatePool2(emu, [0x100, 0x50, tag])
+
+    assert chunk != 0
+    pool_type, size, decoded_tag = emu.pool_allocs[-1]
+    assert pool_type == ddk.POOL_TYPE.PagedPool
+    assert size == 0x50
+    assert decoded_tag == "Face"
+
+
+def test_ex_allocate_pool2_defaults_to_nonpaged(emu):
+    api = make_api(emu)
+    tag = int.from_bytes(b"tada", "little")
+
+    chunk = api.ExAllocatePool2(emu, [0x0, 0x30, tag])
+
+    assert chunk != 0
+    pool_type, size, decoded_tag = emu.pool_allocs[-1]
+    assert pool_type == ddk.POOL_TYPE.NonPagedPool
+    assert size == 0x30
+    assert decoded_tag == "tada"
+
+
+def test_ex_allocate_pool2_zero_size_allocates_nothing(emu):
+    api = make_api(emu)
+
+    chunk = api.ExAllocatePool2(emu, [0x100, 0, 0])
+
+    assert chunk == 0
+    assert not emu.pool_allocs
+
+
+def test_ps_get_current_process_id_returns_active_pid(emu):
+    api = make_api(emu)
+    emu.process = FakeProcess(pid=0x1234)
+
+    assert api.PsGetCurrentProcessId(emu, []) == 0x1234
+
+
+def test_ps_get_current_process_id_defaults_to_system_pid(emu):
+    api = make_api(emu)
+    emu.process = None
+
+    assert api.PsGetCurrentProcessId(emu, []) == 4


### PR DESCRIPTION
Did some driver analysis this weekend and had to vibe-patch speakeasy to work with the driver I was looking at and thought I would open a PR for the changes ( driver I was looking at https://crackmes.one/crackme/69db34d6b38f9259eec7eb32 ). I have two PRs, this one is low risk, I'll open the second one shortly which is likely higher risk/worth a discussion.

I hit a bug  with DbgPrint("%zu", size) calls: 
%zu/%jd/%tx were raising ValueError because the size modifiers weren't recognized.
The fix was to treat z/j/t  formatters more or less the same way the existing code already treated ll

I also added support for a couple of functions I needed for this crackme: KeAcquireSpinLock/KeReleaseSpinLock, ExAllocatePool2, PsGetCurrentProcessId
KeInitializeSpinLock, KeAcquireSpinLock, KeReleaseSpinLock:  match the real WDK signatures exactly (PKSPIN_LOCK, PKIRQL/KIRQL args). They reuse the emulator's existing get_current_irql/set_current_irql plumbing.
ExAllocatePool2: matches the real signature (FLAGS Flags, SIZE_T Size, ULONG Tag). I checked the 0x100 constant used for POOL_FLAG_PAGED against the actual WDK definitions.
PsGetCurrentProcessId: returns p.pid or falls back to 4 if pid is missing.

Attaching the report.json this generated for that .sys

[report_tbkmd.json](https://github.com/user-attachments/files/31390570/report_tbkmd.json)