### PR TITLE
gdb: fix connection drop on large hardware execute breakpoints

### DIFF
--- a/speakeasy/gdb.py
+++ b/speakeasy/gdb.py
@@ -22,7 +22,7 @@ from speakeasy.winenv import arch
 
 logger = logging.getLogger(__name__)
 
-_PACKET_SIZE = 0x4000
+_PACKET_SIZE = 0x10000
 
 
 def _rsp_packet(payload: bytes) -> bytes:
@@ -263,7 +263,17 @@ class GdbServer:
             payload = self._commands.get()
             if payload is None:
                 return ResumeAction(detach=True)
-            action = self._handle_command(payload)
+            try:
+                action = self._handle_command(payload)
+            except OSError:
+                return ResumeAction(detach=True)
+            except Exception:
+                logger.warning("unhandled exception processing GDB command %r", payload, exc_info=True)
+                try:
+                    self._reply(b"E01")
+                except OSError:
+                    return ResumeAction(detach=True)
+                continue
             if action is not None:
                 if not action.detach and not action.kill:
                     # Mark the resume transition so Ctrl-C arriving before
@@ -381,7 +391,7 @@ class GdbServer:
     def _handle_command(self, payload: bytes) -> ResumeAction | None:
         if payload.startswith(b"qSupported"):
             self._reply(
-                b"PacketSize=4000;qXfer:features:read+;qXfer:libraries:read+;"
+                b"PacketSize=10000;qXfer:features:read+;qXfer:libraries:read+;"
                 b"qXfer:exec-file:read+;qXfer:threads:read+;qXfer:memory-map:read+;"
                 b"QStartNoAckMode+;vContSupported+;swbreak+;hwbreak+"
             )
@@ -491,6 +501,9 @@ class GdbServer:
             self._refresh_hooks()
             self._reply(b"OK")
         except ValueError:
+            self._reply(b"E01")
+        except Exception:
+            logger.warning("breakpoint command failed: %r", payload, exc_info=True)
             self._reply(b"E01")
 
     # ------------------------------------------------------------------
@@ -617,7 +630,7 @@ class GdbServer:
         try:
             address_text, size_text = payload.split(b",", 1)
             address, size = int(address_text, 16), int(size_text, 16)
-            if address < 0 or size < 0 or size > _PACKET_SIZE // 2:
+            if address < 0 or size < 0 or size > (_PACKET_SIZE - 1) // 2:
                 raise ValueError
             self._reply(bytes(self.emu.mem_read(address, size)).hex().encode("ascii"))
         except Exception:

--- a/speakeasy/winenv/api/usermode/kernel32.py
+++ b/speakeasy/winenv/api/usermode/kernel32.py
@@ -1266,9 +1266,7 @@ class Kernel32(api.ApiHandler):
         if lpThreadId:
             self.mem_write(lpThreadId, obj.id.to_bytes(4, "little"))
 
-        self.record_process_event(
-            proc_obj, THREAD_CREATE, start_addr=lpStartAddress, param=lpParameter, tid=obj.id
-        )
+        self.record_process_event(proc_obj, THREAD_CREATE, start_addr=lpStartAddress, param=lpParameter, tid=obj.id)
 
         emu.set_last_error(windefs.ERROR_SUCCESS)
 

--- a/tests/test_gdb.py
+++ b/tests/test_gdb.py
@@ -483,3 +483,26 @@ def test_gdb_single_step(gdb_emulator):
         client.continue_()
     finally:
         client.close()
+
+
+def test_gdb_hardware_breakpoint_large_range(gdb_emulator):
+    client = GdbRspClient(gdb_emulator)
+    try:
+        client.query_halt_reason()
+        eip = client.read_x86_registers().eip
+
+        for size in (0x1C000, 0x28000, 0x2D000):
+            assert client.query(f"Z1,{eip:x},{size:x}") == "OK"
+            assert client.query(f"z1,{eip:x},{size:x}") == "OK"
+
+        assert client.query(f"Z1,{eip:x},2d000") == "OK"
+        stop = client.continue_()
+        assert stop.startswith("T05")
+        assert "hwbreak:;" in stop
+
+        assert client.read_registers()
+
+        assert client.query(f"z1,{eip:x},2d000") == "OK"
+        assert client.continue_().startswith(("T", "W"))
+    finally:
+        client.close()

--- a/tests/test_gdb_compat.py
+++ b/tests/test_gdb_compat.py
@@ -4,7 +4,7 @@ from xml.etree import ElementTree
 
 from unicorn import UC_ARCH_X86, UC_MODE_64, Uc
 
-from speakeasy.gdb import GdbServer, ResumeAction, _rsp_escape, _rsp_packet
+from speakeasy.gdb import _PACKET_SIZE, GdbServer, ResumeAction, _rsp_escape, _rsp_packet
 from speakeasy.winenv import arch
 
 
@@ -133,7 +133,7 @@ def test_packet_extraction_validates_checksum_across_fragmented_input():
     trailing_escape = _rsp_packet(b"qC}")
     assert GdbServer._extract_packet(bytearray(trailing_escape))[2] is False
 
-    oversized_payload = b"q" * (0x4000 + 1)
+    oversized_payload = b"q" * (_PACKET_SIZE + 1)
     oversized = _rsp_packet(oversized_payload)
     assert GdbServer._extract_packet(bytearray(oversized))[2] is False
 
@@ -214,11 +214,56 @@ def test_x87_registers_use_full_80_bit_wire_format():
 
 def test_xfer_escaping_respects_advertised_packet_size():
     server = make_server()
-    server._executable_path = lambda: "$#}*" * 5000
+    server._executable_path = lambda: "$#}*" * 50000
 
     response = server._handle_xfer(b"qXfer:exec-file:read::0,ffff")
     encoded = response[:1] + _rsp_escape(response[1:])
 
     assert response.startswith(b"m")
-    assert len(encoded) <= 0x4000
+    assert len(encoded) <= _PACKET_SIZE
     assert all(value not in encoded[1:] for value in b"$#*")
+
+
+def test_hardware_breakpoint_accepts_large_ranges():
+    server = make_server()
+    replies = []
+    server._reply = replies.append
+    server._install_hooks()
+
+    for size_hex in ("1c000", "28000", "2d000", "100000"):
+        server._change_breakpoint(f"Z1,401000,{size_hex}".encode())
+
+    assert replies == [b"OK"] * 4
+    assert len(server._exec_breakpoints) == 4
+    assert (0x401000, 0x2D000) in server._exec_breakpoints
+
+
+def test_hardware_breakpoint_range_hit_detection():
+    server = make_server()
+    reasons = []
+    server._request_stop = reasons.append
+    server._exec_breakpoints[(0x401000, 0x2D000)] = 1
+
+    server._on_code(None, 0x401000, 1)
+    server._on_code(None, 0x42DFFF, 1)
+    server._on_code(None, 0x415000, 1)
+    server._on_code(None, 0x42E000, 1)
+    server._on_code(None, 0x400FFF, 1)
+
+    assert len(reasons) == 3
+    assert all(r.kind == "hwbreak" for r in reasons)
+
+
+def test_change_breakpoint_survives_hook_error(caplog):
+    server = make_server()
+    replies = []
+    server._reply = replies.append
+
+    def failing_refresh():
+        raise RuntimeError("simulated Unicorn error")
+
+    server._refresh_hooks = failing_refresh
+    server._change_breakpoint(b"Z1,401000,2d000")
+
+    assert replies == [b"E01"]
+    assert any("breakpoint command failed" in r.message for r in caplog.records)


### PR DESCRIPTION
## Summary

- theory: an unpacker requests Z1 hardware execute breakpoints spanning entire packed sections (e.g. `Z1,401000,2d000`). When the Unicorn code hook was re-added via `_refresh_hooks()`, a `UcError` propagated uncaught through `command_loop` into the `GdbServer` context manager, triggering socket teardown and IDA's `DBG_ERROR`.
- Widen `_change_breakpoint` exception handling from `ValueError` to also catch unexpected exceptions (with `logger.warning` so they surface in logs instead of silently killing the session).
- Add exception safety around `_handle_command` in `command_loop` so unhandled errors reply `E01` instead of crashing the server.
- Increase `_PACKET_SIZE` from `0x4000` to `0x10000` for standard GDB compatibility.
- Fix off-by-one in `_read_memory` size guard.

## Test plan

- [x] New unit test `test_hardware_breakpoint_accepts_large_ranges` verifies Z1 with sizes 0x1c000, 0x28000, 0x2d000, 0x100000
- [x] New unit test `test_hardware_breakpoint_range_hit_detection` verifies code hook hit/miss for range breakpoints
- [x] New unit test `test_change_breakpoint_survives_hook_error` verifies E01 reply + warning log when `_refresh_hooks` raises
- [x] Existing test suite passes (15/15 compat, 9/10 integration — 1 pre-existing port collision)

🤖 Generated with [Claude Code](https://claude.com/claude-code)