### PR TITLE
gdb: send library events during module load

### DIFF
--- a/doc/gdb.md
+++ b/doc/gdb.md
@@ -149,7 +149,7 @@ se.run_module(module)
 
 Speakeasy implements the all-stop GDB Remote Serial Protocol directly. The server provides register and memory access, software and hardware breakpoints, watchpoints, single-step, asynchronous Ctrl-C pause, and the Windows process metadata used by IDA:
 
-- `qXfer:libraries:read` returns all mapped Speakeasy PE modules
+- `qXfer:libraries:read` returns all mapped Speakeasy PE modules; mapping one while the target runs (for example through `LoadLibrary`) halts it with the `library` stop reason so the client re-reads the list
 - `qXfer:exec-file:read` returns the emulated executable path
 - `qXfer:threads:read`, `qfThreadInfo`, and `qGetTIBAddr` describe the active emulated thread
 - `qXfer:features:read` reports a register layout matching the emulated architecture
@@ -173,7 +173,7 @@ The server implements the all-stop RSP subset exercised by GDB and IDA:
 | Registers | `g`, `G`, `p`, `P` |
 | Memory | `m`, `M`, `X` |
 | Breakpoints | `Z0`/`z0`, `Z1`/`z1`, and read/write/access watchpoints |
-| Execution | `c`, `s`, `vCont`, asynchronous Ctrl-C, `?` |
+| Execution | `c`, `s`, `vCont`, asynchronous Ctrl-C, `?`, `swbreak`/`hwbreak`/watchpoint/`library` stop replies |
 | Lifecycle | `D`, `k`, and `Wxx` exit replies |
 
 Unsupported optional packets receive an empty response as required by RSP. Non-stop mode, multiprocess mode, reverse execution, and remote file I/O are not advertised.
@@ -183,6 +183,7 @@ Unsupported optional packets receive an empty response as required by RSP. Non-s
 - one debugger client can connect to a Speakeasy instance
 - Speakeasy models Windows thread objects but executes one Unicorn CPU context at a time; the server therefore presents the currently active execution context as one synthetic GDB thread
 - breakpoints persist across runs: Speakeasy executes multiple runs (for example TLS callbacks, the module entry point, and exports)
+- modules stay mapped for the life of the emulation, so the server reports library loads but never unloads
 - reverse execution, non-stop mode, and multiprocess RSP are not implemented
 
 ## Related docs

--- a/speakeasy/gdb.py
+++ b/speakeasy/gdb.py
@@ -93,6 +93,7 @@ class GdbServer:
         self._running = False
         self._stop_reason = StopReason()
         self._stop_pending = False
+        self._library_list_changed = False
         self._resume_from_breakpoint: int | None = None
         self._exec_breakpoints: dict[tuple[int, int], int] = {}
         self._read_watchpoints: dict[tuple[int, int], int] = {}
@@ -136,6 +137,9 @@ class GdbServer:
         self._client = client
         logger.info("GDB client connected from %s:%d", *address[:2])
         self._install_hooks()
+        listeners = getattr(self.emu, "module_change_listeners", None)
+        if listeners is not None:
+            listeners.append(self._on_module_change)
         self._reader = threading.Thread(target=self._read_loop, name="speakeasy-gdb-reader", daemon=True)
         self._reader.start()
 
@@ -165,6 +169,9 @@ class GdbServer:
                     sock.close()
                 except OSError:
                     pass
+        listeners = getattr(self.emu, "module_change_listeners", None)
+        if listeners is not None and self._on_module_change in listeners:
+            listeners.remove(self._on_module_change)
         for hook in self._hooks:
             try:
                 self._remove_hook(hook)
@@ -312,6 +319,11 @@ class GdbServer:
             self._stop_pending = True
         if self.emu.emu_eng is not None:
             self.emu.emu_eng.stop()
+
+    def _on_module_change(self) -> None:
+        with self._state_lock:
+            self._library_list_changed = True
+        self._request_stop(StopReason(kind="library"))
 
     def _interrupt(self) -> None:
         with self._state_lock:
@@ -779,11 +791,15 @@ class GdbServer:
         teb = getattr(thread, "teb", None)
         return int(getattr(teb, "address", 0) or 0)
 
-    @staticmethod
-    def _stop_reply(reason: StopReason) -> bytes:
+    def _stop_reply(self, reason: StopReason) -> bytes:
         reply = f"T{reason.signal:02x}thread:1;".encode("ascii")
         if reason.kind in ("swbreak", "hwbreak"):
             reply += reason.kind.encode("ascii") + b":;"
         elif reason.kind in ("watch", "rwatch", "awatch") and reason.address is not None:
             reply += f"{reason.kind}:{reason.address:x};".encode("ascii")
+        with self._state_lock:
+            library_list_changed = self._library_list_changed
+            self._library_list_changed = False
+        if library_list_changed or reason.kind == "library":
+            reply += b"library:;"
         return reply

--- a/speakeasy/gdb.py
+++ b/speakeasy/gdb.py
@@ -137,9 +137,7 @@ class GdbServer:
         self._client = client
         logger.info("GDB client connected from %s:%d", *address[:2])
         self._install_hooks()
-        listeners = getattr(self.emu, "module_change_listeners", None)
-        if listeners is not None:
-            listeners.append(self._on_module_change)
+        self.emu.module_change_listeners.append(self._on_module_change)
         self._reader = threading.Thread(target=self._read_loop, name="speakeasy-gdb-reader", daemon=True)
         self._reader.start()
 
@@ -169,9 +167,8 @@ class GdbServer:
                     sock.close()
                 except OSError:
                     pass
-        listeners = getattr(self.emu, "module_change_listeners", None)
-        if listeners is not None and self._on_module_change in listeners:
-            listeners.remove(self._on_module_change)
+        if self._on_module_change in self.emu.module_change_listeners:
+            self.emu.module_change_listeners.remove(self._on_module_change)
         for hook in self._hooks:
             try:
                 self._remove_hook(hook)
@@ -797,9 +794,11 @@ class GdbServer:
             reply += reason.kind.encode("ascii") + b":;"
         elif reason.kind in ("watch", "rwatch", "awatch") and reason.address is not None:
             reply += f"{reason.kind}:{reason.address:x};".encode("ascii")
+        # A library change is a flag rather than a stop kind, so it can coalesce
+        # with another pending stop reason or with a whole dependency chain.
         with self._state_lock:
             library_list_changed = self._library_list_changed
             self._library_list_changed = False
-        if library_list_changed or reason.kind == "library":
+        if library_list_changed:
             reply += b"library:;"
         return reply

--- a/speakeasy/windows/winemu.py
+++ b/speakeasy/windows/winemu.py
@@ -6,6 +6,7 @@ import os
 import shlex
 import traceback
 from abc import abstractmethod
+from collections.abc import Callable
 from enum import IntEnum
 from typing import Any
 
@@ -91,6 +92,7 @@ class WindowsEmulator(BinaryEmulator):
         self.gdb_host: str | None = gdb_host
         self.arch: int = 0
         self.modules: list[Any] = []
+        self.module_change_listeners: list[Callable[[], None]] = []
         self._setup_done: bool = False
         self.bootstrap_phase: BootstrapPhase = BootstrapPhase.INITIALIZED
         self.curr_run: Run | None = None
@@ -1214,6 +1216,11 @@ class WindowsEmulator(BinaryEmulator):
                 self.profiler.strings["unicode"] = [u[1] for u in self.get_unicode_strings(raw)]
 
         self.modules.append(mod)
+        for listener in tuple(self.module_change_listeners):
+            try:
+                listener()
+            except Exception:
+                logger.warning("module change listener failed", exc_info=True)
 
         if is_primary and not self.stack_base and image.stack_size:
             stack_size = self.config.stack_size or image.stack_size

--- a/tests/test_gdb.py
+++ b/tests/test_gdb.py
@@ -226,10 +226,10 @@ _LIBRARY_LOAD_SERVER_SCRIPT = textwrap.dedent("""\
 
     loaded = []
 
-    def load_once(emu, addr, size):
+    def load_once(*args, **kwargs):
         if not loaded:
             loaded.append(True)
-            se.emu.load_module_by_name("gdbtest319")
+            se.emu.load_module_by_name("gdbtestlib")
 
     se.emu.add_code_hook(cb=load_once)
     se.run_shellcode(address)
@@ -405,6 +405,20 @@ def gdb_exit_emulator():
     _stop_server(proc)
 
 
+@pytest.fixture
+def gdb_library_load_emulator():
+    port = _find_free_port()
+    config_path = os.path.join(TESTS_DIR, "test.json")
+    proc = subprocess.Popen(
+        [sys.executable, "-c", _LIBRARY_LOAD_SERVER_SCRIPT, str(port), config_path],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    _wait_for_port(port, proc)
+    yield port
+    _stop_server(proc)
+
+
 def test_gdb_breakpoint_stop_keeps_session_alive(gdb_emulator):
     import capstone
 
@@ -432,20 +446,6 @@ def test_gdb_breakpoint_stop_keeps_session_alive(gdb_emulator):
         client.close()
 
 
-@pytest.fixture
-def gdb_library_load_emulator():
-    port = _find_free_port()
-    config_path = os.path.join(TESTS_DIR, "test.json")
-    proc = subprocess.Popen(
-        [sys.executable, "-c", _LIBRARY_LOAD_SERVER_SCRIPT, str(port), config_path],
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
-    )
-    _wait_for_port(port, proc)
-    yield port
-    _stop_server(proc)
-
-
 def test_gdb_reports_runtime_library_load(gdb_library_load_emulator):
     client = GdbRspClient(gdb_library_load_emulator)
     try:
@@ -453,14 +453,14 @@ def test_gdb_reports_runtime_library_load(gdb_library_load_emulator):
 
         libraries = client.query("qXfer:libraries:read::0,4000")
         assert libraries.startswith("l<library-list")
-        assert "gdbtest319" not in libraries
+        assert "gdbtestlib.dll" not in libraries
 
         stop = client.continue_()
         assert stop.startswith("T05")
         assert "library:;" in stop
 
         libraries = client.query("qXfer:libraries:read::0,4000")
-        assert "gdbtest319.dll" in libraries
+        assert "gdbtestlib.dll" in libraries
 
         # The library change was reported; the next stop must not repeat it.
         client.send_no_wait("c")

--- a/tests/test_gdb.py
+++ b/tests/test_gdb.py
@@ -210,6 +210,33 @@ _EXIT_SERVER_SCRIPT = textwrap.dedent("""\
 """)
 
 
+_LIBRARY_LOAD_SERVER_SCRIPT = textwrap.dedent("""\
+    import json
+    import sys
+
+    from speakeasy import Speakeasy
+
+    port = int(sys.argv[1])
+    config_path = sys.argv[2]
+    with open(config_path) as f:
+        cfg = json.load(f)
+
+    se = Speakeasy(config=cfg, gdb_port=port)
+    address = se.load_shellcode(data=b"\\x90\\xeb\\xfe", arch="x86")
+
+    loaded = []
+
+    def load_once(emu, addr, size):
+        if not loaded:
+            loaded.append(True)
+            se.emu.load_module_by_name("gdbtest319")
+
+    se.emu.add_code_hook(cb=load_once)
+    se.run_shellcode(address)
+    se.shutdown()
+""")
+
+
 _SERVER_SCRIPT = textwrap.dedent("""\
     import json
     import lzma
@@ -401,6 +428,46 @@ def test_gdb_breakpoint_stop_keeps_session_alive(gdb_emulator):
 
         assert client.query(f"z0,{breakpoint:x},1") == "OK"
         assert client.continue_().startswith(("T", "W"))
+    finally:
+        client.close()
+
+
+@pytest.fixture
+def gdb_library_load_emulator():
+    port = _find_free_port()
+    config_path = os.path.join(TESTS_DIR, "test.json")
+    proc = subprocess.Popen(
+        [sys.executable, "-c", _LIBRARY_LOAD_SERVER_SCRIPT, str(port), config_path],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    _wait_for_port(port, proc)
+    yield port
+    _stop_server(proc)
+
+
+def test_gdb_reports_runtime_library_load(gdb_library_load_emulator):
+    client = GdbRspClient(gdb_library_load_emulator)
+    try:
+        client.query_halt_reason()
+
+        libraries = client.query("qXfer:libraries:read::0,4000")
+        assert libraries.startswith("l<library-list")
+        assert "gdbtest319" not in libraries
+
+        stop = client.continue_()
+        assert stop.startswith("T05")
+        assert "library:;" in stop
+
+        libraries = client.query("qXfer:libraries:read::0,4000")
+        assert "gdbtest319.dll" in libraries
+
+        # The library change was reported; the next stop must not repeat it.
+        client.send_no_wait("c")
+        time.sleep(0.05)
+        stop = client.interrupt()
+        assert stop.startswith("T02")
+        assert "library:;" not in stop
     finally:
         client.close()
 

--- a/tests/test_gdb_compat.py
+++ b/tests/test_gdb_compat.py
@@ -201,16 +201,22 @@ def test_access_watchpoint_reports_awatch_stop_reason():
     assert b"awatch:1001;" in server._stop_reply(reasons[0])
 
 
-def test_library_stop_reason_reports_library_change():
+def test_module_change_requests_library_stop_reason():
     server = make_server()
+    reasons = []
+    server._request_stop = reasons.append
 
-    reply = server._stop_reply(StopReason(kind="library"))
+    server._on_module_change()
 
+    assert len(reasons) == 1
+    assert reasons[0].kind == "library"
+
+    reply = server._stop_reply(reasons[0])
     assert reply.startswith(b"T05")
     assert b"library:;" in reply
 
 
-def test_library_change_flag_piggybacks_on_next_stop_reply_and_clears():
+def test_library_change_piggybacks_on_next_stop_reply_and_is_reported_once():
     server = make_server()
     server._library_list_changed = True
 
@@ -223,25 +229,13 @@ def test_library_change_flag_piggybacks_on_next_stop_reply_and_clears():
     assert b"library:;" not in second
 
 
-def test_module_change_while_running_requests_library_stop():
-    server = make_server()
-    reasons = []
-    server._request_stop = reasons.append
-
-    server._on_module_change()
-
-    assert server._library_list_changed
-    assert len(reasons) == 1
-    assert reasons[0].kind == "library"
-
-
-def test_module_change_listener_registration_follows_session_lifetime():
+def test_module_change_listener_is_removed_when_session_closes():
     server = make_server()
     server.emu.module_change_listeners.append(server._on_module_change)
 
     server.close()
 
-    assert server._on_module_change not in server.emu.module_change_listeners
+    assert server.emu.module_change_listeners == []
 
 
 def test_x87_registers_use_full_80_bit_wire_format():

--- a/tests/test_gdb_compat.py
+++ b/tests/test_gdb_compat.py
@@ -4,7 +4,7 @@ from xml.etree import ElementTree
 
 from unicorn import UC_ARCH_X86, UC_MODE_64, Uc
 
-from speakeasy.gdb import _PACKET_SIZE, GdbServer, ResumeAction, _rsp_escape, _rsp_packet
+from speakeasy.gdb import _PACKET_SIZE, GdbServer, ResumeAction, StopReason, _rsp_escape, _rsp_packet
 from speakeasy.winenv import arch
 
 
@@ -45,6 +45,7 @@ class DummyEmulator:
             DummyModule(r"C:\Windows\System32\weird&name.dll", 0x70000000),
         ]
         self.curr_thread = DummyThread(DummyTeb(0x7FFDE000))
+        self.module_change_listeners = []
 
     def get_arch(self):
         return arch.ARCH_AMD64
@@ -198,6 +199,49 @@ def test_access_watchpoint_reports_awatch_stop_reason():
     assert len(reasons) == 1
     assert reasons[0].kind == "awatch"
     assert b"awatch:1001;" in server._stop_reply(reasons[0])
+
+
+def test_library_stop_reason_reports_library_change():
+    server = make_server()
+
+    reply = server._stop_reply(StopReason(kind="library"))
+
+    assert reply.startswith(b"T05")
+    assert b"library:;" in reply
+
+
+def test_library_change_flag_piggybacks_on_next_stop_reply_and_clears():
+    server = make_server()
+    server._library_list_changed = True
+
+    breakpoint_reason = StopReason(kind="swbreak")
+    first = server._stop_reply(breakpoint_reason)
+    second = server._stop_reply(breakpoint_reason)
+
+    assert b"swbreak:;" in first
+    assert b"library:;" in first
+    assert b"library:;" not in second
+
+
+def test_module_change_while_running_requests_library_stop():
+    server = make_server()
+    reasons = []
+    server._request_stop = reasons.append
+
+    server._on_module_change()
+
+    assert server._library_list_changed
+    assert len(reasons) == 1
+    assert reasons[0].kind == "library"
+
+
+def test_module_change_listener_registration_follows_session_lifetime():
+    server = make_server()
+    server.emu.module_change_listeners.append(server._on_module_change)
+
+    server.close()
+
+    assert server._on_module_change not in server.emu.module_change_listeners
 
 
 def test_x87_registers_use_full_80_bit_wire_format():


### PR DESCRIPTION
Closes #319

When a module is mapped at runtime (for example by `LoadLibrary`), the gdb stub requests a stop and replies with the `library` stop reason (`T05thread:1;library:;`). Clients such as IDA then re-read `qXfer:libraries:read`, diff the list against what they knew, and fire `LIB_LOADED` events, so runtime-loaded DLLs appear in the Modules window without a manual refresh. This matches Windows gdbserver semantics: the `LoadLibrary` handler completes fully (module mapped, PEB updated, return value written) before unicorn halts, and the client resumes on its own unless the user chose to suspend on library load.

## Changes

- `WindowsEmulator` gains `module_change_listeners`, notified after `load_image` appends to `emu.modules` (the single mutation point for the module list). Listener errors are logged, never propagated into emulation.
- `GdbServer` registers a listener for the session lifetime (added on client connect, removed in `close()`). A module change sets `_library_list_changed` and requests a stop through the existing `_request_stop` machinery.
- `_stop_reply` appends `library:;` from that flag alone and clears it, so the field can coalesce with another pending stop reason (a breakpoint reached in the same instruction) or with a dependency chain that maps several DLLs before the halt. One stop covers them all, because the client diffs the full list.
- Reading the flag rather than the stop kind also keeps a repeated `?` query from re-reporting an event the client already handled.
- No `qSupported` change: the `library` stop reason is not gated by a feature string, and `qXfer:libraries:read+` is already advertised.

`FreeLibrary` does not unmap, so unload events cannot occur. The mechanism is direction-agnostic (clients diff the full list), so `LIB_UNLOADED` works if module removal is implemented later. `doc/gdb.md` records both the new stop reason and this limitation.

## Testing

- `tests/test_gdb_compat.py`: a module change requests a `library` stop and its reply carries `library:;`; the flag piggybacks on a breakpoint stop reply and is reported once; the listener is removed when the session closes.
- `tests/test_gdb.py`: end-to-end subprocess test that maps a module mid-run through a code hook, asserts the `T05...library:;` stop reply, finds the new DLL in the re-fetched library XML, and confirms the next stop does not repeat the event. Suppressing the notification makes this test time out, so it is not vacuous.
- Full suite: 181 passed, 26 skipped. The 3 failures are pre-existing and come from the uninitialized `tests/capa-testfiles` submodule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)